### PR TITLE
Drop addDynamicObjectMaker from MockspressoProperties

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -50,7 +50,6 @@ interface MockspressoInstance {
 interface MockspressoProperties {
   fun onSetup(cmd: (MockspressoInstance) -> Unit)
   fun onTeardown(cmd: () -> Unit)
-  fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker)
   fun <T : Any?> depOf(key: DependencyKey<T>, maker: () -> T): Lazy<T>
   fun <T : Any?> findDepOf(key: DependencyKey<T>): Lazy<T>
   fun <BIND : Any?, IMPL : BIND> realImplOf(key: DependencyKey<BIND>, implementationToken: TypeToken<IMPL>): Lazy<IMPL>

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -67,10 +67,6 @@ private class MockspressoPropertiesContainer(
     builder.onTearDown(cmd)
   }
 
-  override fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker) {
-    builder.addDynamicMaker(dynamicMaker)
-  }
-
   override fun <T> depOf(key: DependencyKey<T>, maker: () -> T): Lazy<T> {
     val lazy = mlazy(maker)
     builder.dependencyOf(key) { lazy.value }


### PR DESCRIPTION
Added this prematurely, I don't think it fits here. Would rather introduce dynamic deps and/or real object inhterceptors