### PR TITLE
Introduce real object interceptors to support spying real objects

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -34,7 +34,7 @@ interface MockspressoBuilder {
   fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder // formerly special object makers
 
   fun <T : Any?> addDependencyOf(key: DependencyKey<T>, provider: () -> T): MockspressoBuilder
-  fun <BIND : Any?, IMPL : BIND>  useRealImplOf(
+  fun <BIND : Any?, IMPL : BIND> useRealImplOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND = { it }
@@ -59,6 +59,6 @@ interface MockspressoProperties {
   fun <BIND : Any?, IMPL : BIND> realImplOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
-    interceptor: (IMPL) -> BIND = { it }
+    interceptor: (IMPL) -> IMPL = { it }
   ): Lazy<IMPL>
 }

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -1,8 +1,8 @@
 package com.episode6.mxo2
 
+import com.episode6.mxo2.api.DynamicObjectMaker
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.api.ObjectMaker
-import com.episode6.mxo2.api.DynamicObjectMaker
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.TypeToken
 
@@ -34,7 +34,11 @@ interface MockspressoBuilder {
   fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder // formerly special object makers
 
   fun <T : Any?> addDependencyOf(key: DependencyKey<T>, provider: () -> T): MockspressoBuilder
-  fun <T : Any?> useRealImplOf(key: DependencyKey<T>, implementationToken: TypeToken<out T>): MockspressoBuilder
+  fun <BIND : Any?, IMPL : BIND>  useRealImplOf(
+    key: DependencyKey<BIND>,
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL) -> BIND = { it }
+  ): MockspressoBuilder
 
   fun testResources(maker: (MockspressoProperties) -> Unit): MockspressoBuilder
 
@@ -52,5 +56,9 @@ interface MockspressoProperties {
   fun onTeardown(cmd: () -> Unit)
   fun <T : Any?> depOf(key: DependencyKey<T>, maker: () -> T): Lazy<T>
   fun <T : Any?> findDepOf(key: DependencyKey<T>): Lazy<T>
-  fun <BIND : Any?, IMPL : BIND> realImplOf(key: DependencyKey<BIND>, implementationToken: TypeToken<IMPL>): Lazy<IMPL>
+  fun <BIND : Any?, IMPL : BIND> realImplOf(
+    key: DependencyKey<BIND>,
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL) -> BIND = { it }
+  ): Lazy<IMPL>
 }

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -32,5 +32,5 @@ inline fun <reified T : Any?> MockspressoProperties.findDep(qualifier: Annotatio
 inline fun <reified T : Any?> MockspressoProperties.realInstance(qualifier: Annotation? = null, noinline interceptor: (T)->T = {it}): Lazy<T> =
   dependencyKey<T>(qualifier).let { realImplOf(it, it.token, interceptor) }
 
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->BIND = {it}): Lazy<IMPL> =
-  realImplOf(dependencyKey<BIND>(qualifier), typeToken())
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->IMPL = {it}): Lazy<IMPL> =
+  realImplOf(dependencyKey<BIND>(qualifier), typeToken(), interceptor)

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -2,15 +2,16 @@ package com.episode6.mxo2
 
 import com.episode6.mxo2.reflect.dependencyKey
 import com.episode6.mxo2.reflect.typeToken
+import kotlin.coroutines.ContinuationInterceptor
 
 inline fun <reified T : Any?> MockspressoBuilder.addDependencyOf(qualifier: Annotation? = null, noinline provider: () -> T): MockspressoBuilder =
   addDependencyOf(dependencyKey(qualifier), provider)
 
-inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(qualifier: Annotation? = null): MockspressoBuilder =
-  dependencyKey<T>(qualifier).let { useRealImplOf(it, it.token) }
+inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(qualifier: Annotation? = null, noinline interceptor: (T)->T = {it}): MockspressoBuilder =
+  dependencyKey<T>(qualifier).let { useRealImplOf(it, it.token, interceptor) }
 
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.useRealImplOf(qualifier: Annotation? = null): MockspressoBuilder =
-  useRealImplOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>())
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.useRealImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->BIND = {it}): MockspressoBuilder =
+  useRealImplOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
 
 
 
@@ -28,8 +29,8 @@ inline fun <reified T : Any?> MockspressoProperties.depOf(qualifier: Annotation?
 inline fun <reified T : Any?> MockspressoProperties.findDep(qualifier: Annotation? = null): Lazy<T> =
   findDepOf(dependencyKey(qualifier))
 
-inline fun <reified T : Any?> MockspressoProperties.realInstance(qualifier: Annotation? = null): Lazy<T> =
-  dependencyKey<T>(qualifier).let { realImplOf(it, it.token) }
+inline fun <reified T : Any?> MockspressoProperties.realInstance(qualifier: Annotation? = null, noinline interceptor: (T)->T = {it}): Lazy<T> =
+  dependencyKey<T>(qualifier).let { realImplOf(it, it.token, interceptor) }
 
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->BIND = {it}): Lazy<IMPL> =
   realImplOf(dependencyKey<BIND>(qualifier), typeToken())

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -80,7 +80,7 @@ private class MockspressoPropertiesContainer(
   override fun <BIND, IMPL : BIND> realImplOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
-    interceptor: (IMPL)->BIND
+    interceptor: (IMPL)->IMPL
   ): Lazy<IMPL> {
     builder.realObject(key, implementationToken, interceptor)
     return mlazy { instance.get(key) as IMPL }

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -37,8 +37,11 @@ internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : 
   override fun <T> addDependencyOf(key: DependencyKey<T>, provider: () -> T): MockspressoBuilder =
     apply { builder.dependencyOf(key, provider) }
 
-  override fun <T> useRealImplOf(key: DependencyKey<T>, implementationToken: TypeToken<out T>): MockspressoBuilder =
-    apply { builder.realObject(key, implementationToken) }
+  override fun <BIND : Any?, IMPL : BIND>  useRealImplOf(
+    key: DependencyKey<BIND>,
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL) -> BIND
+  ): MockspressoBuilder = apply { builder.realObject(key, implementationToken, interceptor) }
 
   override fun testResources(maker: (MockspressoProperties) -> Unit): MockspressoBuilder =
     apply { maker(properties) }
@@ -76,9 +79,10 @@ private class MockspressoPropertiesContainer(
   @Suppress("UNCHECKED_CAST")
   override fun <BIND, IMPL : BIND> realImplOf(
     key: DependencyKey<BIND>,
-    implementationToken: TypeToken<IMPL>
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL)->BIND
   ): Lazy<IMPL> {
-    builder.realObject(key, implementationToken)
+    builder.realObject(key, implementationToken, interceptor)
     return mlazy { instance.get(key) as IMPL }
   }
 

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
@@ -72,7 +72,7 @@ internal class MxoInstance(
     realMaker
       .makeObject(realObjectRequests.getImplFor(key), validator.asDependencies())
       .checkedCast(key)
-      .let { realObjectRequests.getInterceptorFor(key).invoke(it) }
+      .let { realObjectRequests.intercept(key, it) }
       .also { if (cache) it.cacheWith(key, validator) }
 
   private fun DependencyValidator.asDependencies(): Dependencies = object : Dependencies {

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
@@ -72,6 +72,7 @@ internal class MxoInstance(
     realMaker
       .makeObject(realObjectRequests.getImplFor(key), validator.asDependencies())
       .checkedCast(key)
+      .let { realObjectRequests.getInterceptorFor(key).invoke(it) }
       .also { if (cache) it.cacheWith(key, validator) }
 
   private fun DependencyValidator.asDependencies(): Dependencies = object : Dependencies {

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstanceBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstanceBuilder.kt
@@ -48,9 +48,13 @@ internal class MxoInstanceBuilder(private val parent: Lazy<MxoInstance>? = null)
     dependencies.put(key, DependencyValidator(key), provider)
   }
 
-  fun <T : Any?> realObject(key: DependencyKey<T>, implementationToken: TypeToken<out T>) {
+  fun <BIND : Any?, IMPL : BIND> realObject(
+    key: DependencyKey<BIND>,
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL) -> BIND = { it }
+  ) {
     key.assertNotMapped()
-    realObjectRequests.put(key, implementationToken)
+    realObjectRequests.put(key, implementationToken, interceptor)
   }
 
   private fun DependencyKey<*>.assertNotMapped() {

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
@@ -13,7 +13,7 @@ internal class RealObjectRequestsList {
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND
   ) {
-    map[key] = RealObjectRequest(implementationToken, interceptor as (Any) -> Any)
+    map[key] = RealObjectRequest(implementationToken, interceptor as (Any?) -> Any?)
   }
 
   fun <T : Any?> getImplFor(key: DependencyKey<T>): DependencyKey<out T> = DependencyKey(
@@ -21,12 +21,10 @@ internal class RealObjectRequestsList {
     qualifier = key.qualifier
   )
 
-  fun <T : Any?> getInterceptorFor(key: DependencyKey<T>): (T) -> T {
-    if (containsKey(key)) {
-      return map[key]!!.interceptor as (T) -> T
-    } else {
-      return { it }
-    }
+  // apply the interceptor lambda to the supplied [value] and return the result
+  fun <T : Any?> intercept(key: DependencyKey<T>, value: T): T = when {
+    containsKey(key) -> (map[key]!!.interceptor as (T) -> T).invoke(value)
+    else             -> value
   }
 
   fun forEach(consumer: (DependencyKey<*>) -> Unit) {
@@ -34,4 +32,4 @@ internal class RealObjectRequestsList {
   }
 }
 
-private data class RealObjectRequest(val implToken: TypeToken<*>, val interceptor: (Any) -> Any)
+private data class RealObjectRequest(val implToken: TypeToken<*>, val interceptor: (Any?) -> Any?)

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
@@ -8,7 +8,11 @@ internal class RealObjectRequestsList {
   private val map: MutableMap<DependencyKey<*>, RealObjectRequest> = mutableMapOf()
   fun containsKey(key: DependencyKey<*>): Boolean = map.containsKey(key)
 
-  fun <BIND : Any?, IMPL : BIND> put(key: DependencyKey<BIND>, implementationToken: TypeToken<IMPL>, interceptor: (IMPL) -> BIND) {
+  fun <BIND : Any?, IMPL : BIND> put(
+    key: DependencyKey<BIND>,
+    implementationToken: TypeToken<IMPL>,
+    interceptor: (IMPL) -> BIND
+  ) {
     map[key] = RealObjectRequest(implementationToken, interceptor as (Any) -> Any)
   }
 
@@ -30,4 +34,4 @@ internal class RealObjectRequestsList {
   }
 }
 
-internal data class RealObjectRequest(val implToken: TypeToken<*>, val interceptor: (Any) -> Any)
+private data class RealObjectRequest(val implToken: TypeToken<*>, val interceptor: (Any) -> Any)

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/RealObjectRequestsList.kt
@@ -3,21 +3,31 @@ package com.episode6.mxo2.internal
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.TypeToken
 
+@Suppress("UNCHECKED_CAST")
 internal class RealObjectRequestsList {
-  private val map: MutableMap<DependencyKey<*>, TypeToken<*>> = mutableMapOf()
+  private val map: MutableMap<DependencyKey<*>, RealObjectRequest> = mutableMapOf()
   fun containsKey(key: DependencyKey<*>): Boolean = map.containsKey(key)
 
-  fun <T : Any?> put(key: DependencyKey<T>, implementationToken: TypeToken<out T>) {
-    map[key] = implementationToken
+  fun <BIND : Any?, IMPL : BIND> put(key: DependencyKey<BIND>, implementationToken: TypeToken<IMPL>, interceptor: (IMPL) -> BIND) {
+    map[key] = RealObjectRequest(implementationToken, interceptor as (Any) -> Any)
   }
 
-  @Suppress("UNCHECKED_CAST")
   fun <T : Any?> getImplFor(key: DependencyKey<T>): DependencyKey<out T> = DependencyKey(
-    token = if (map.containsKey(key)) map[key]!! as TypeToken<out T> else key.token,
+    token = if (map.containsKey(key)) map[key]!!.implToken as TypeToken<out T> else key.token,
     qualifier = key.qualifier
   )
+
+  fun <T : Any?> getInterceptorFor(key: DependencyKey<T>): (T) -> T {
+    if (containsKey(key)) {
+      return map[key]!!.interceptor as (T) -> T
+    } else {
+      return { it }
+    }
+  }
 
   fun forEach(consumer: (DependencyKey<*>) -> Unit) {
     map.keys.forEach(consumer)
   }
 }
+
+internal data class RealObjectRequest(val implToken: TypeToken<*>, val interceptor: (Any) -> Any)

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -2,6 +2,8 @@ package com.episode6.mxo2
 
 import assertk.assertThat
 import assertk.assertions.*
+import io.mockk.spyk
+import io.mockk.verify
 import kotlin.test.Test
 
 @Suppress("UNUSED_VARIABLE") // We need to hold refs to some values to set up our test cases. If these were real tests the vars would not be unused.
@@ -86,6 +88,19 @@ class SimpleIntegrationTest {
     assertThat {
       mxo.findDependency<SomeDependency1>()
     }.isFailure().hasClass(NoFallbackMakerProvidedError::class)
+  }
+
+  @Test fun testInterceptSpyk() {
+    val mxo = MockspressoBuilder()
+      .addDependencyOf { SomeDependency1() }
+      .build()
+
+    val dep2: SomeDependency2 by mxo.realInstance { spyk(it) }
+    val objUnderTest: SomeObject by mxo.realInstance()
+
+    assertThat(dep2).isEqualTo(objUnderTest.dependency2)
+    objUnderTest.dependency2.doSomething()
+    verify { dep2.doSomething() }
   }
 
   private class SomeObject(val dependency1: SomeDependency1, val dependency2: SomeDependency2) {

--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -1,16 +1,14 @@
 package com.episode6.mxo2.plugins.mockito
 
-import com.episode6.mxo2.MockspressoBuilder
-import com.episode6.mxo2.MockspressoProperties
-import com.episode6.mxo2.addDependencyOf
+import com.episode6.mxo2.*
 import com.episode6.mxo2.api.FallbackObjectMaker
-import com.episode6.mxo2.depOf
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.asKClass
 import org.mockito.Incubating
 import org.mockito.Mockito
 import org.mockito.kotlin.KStubbing
 import org.mockito.kotlin.UseConstructor
+import org.mockito.kotlin.spy
 import org.mockito.listeners.InvocationListener
 import org.mockito.mock.SerializableMode
 import org.mockito.stubbing.Answer
@@ -170,3 +168,39 @@ inline fun <reified T : Any> MockspressoProperties.mock(
     stubbing = stubbing,
   )
 }
+
+/**
+ * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be par of the mockspresso
+ * graph and can be used by other real objects (and then verified in test code).
+ */
+inline fun <reified T : Any> MockspressoProperties.spy(qualifier: Annotation? = null): Lazy<T> =
+  realInstance(qualifier) { spy(it) }
+
+/**
+ * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be par of the mockspresso
+ * graph and can be used by other real objects (and then verified in test code). The [stubbing] will be applied to the
+ * spy before it is injected as a dependency into other classes.
+ */
+inline fun <reified T : Any> MockspressoProperties.spy(
+  qualifier: Annotation? = null,
+  noinline stubbing: KStubbing<T>.(T) -> Unit
+): Lazy<T> = realInstance(qualifier) { spy(it, stubbing) }
+
+/**
+ * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
+ * using type [BIND]). This spy will be par of the mockspresso graph and can be used by other real objects
+ * (and then verified in test code).
+ */
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
+  realInstance(qualifier) { spy(it) }
+
+/**
+ * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
+ * using type [BIND]). This spy will be par of the mockspresso graph and can be used by other real objects
+ * (and then verified in test code). The [stubbing] will be applied to the spy before it is injected as a dependency
+ * into other classes.
+ */
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(
+  qualifier: Annotation? = null,
+  noinline stubbing: KStubbing<IMPL>.(IMPL) -> Unit
+): Lazy<IMPL> = realInstance(qualifier) { spy(it, stubbing) }

--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -192,7 +192,7 @@ inline fun <reified T : Any> MockspressoProperties.spy(
  * (and then verified in test code).
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
-  realInstance(qualifier) { spy(it) }
+  realImplOf<BIND, IMPL>(qualifier) { spy(it) }
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
@@ -203,4 +203,4 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyI
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(
   qualifier: Annotation? = null,
   noinline stubbing: KStubbing<IMPL>.(IMPL) -> Unit
-): Lazy<IMPL> = realInstance(qualifier) { spy(it, stubbing) }
+): Lazy<IMPL> = realImplOf<BIND, IMPL>(qualifier) { spy(it, stubbing) }

--- a/plugins/mockito/src/test/kotlin/com/episode6/mxo2/plugins/mockito/MockitoSpyingTest.kt
+++ b/plugins/mockito/src/test/kotlin/com/episode6/mxo2/plugins/mockito/MockitoSpyingTest.kt
@@ -1,0 +1,60 @@
+package com.episode6.mxo2.plugins.mockito
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.prop
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.realInstance
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.inOrder
+
+class MockitoSpyingTest {
+
+  val mxo = MockspressoBuilder().build()
+
+  private val realObject: TestObj by mxo.realInstance()
+  private val dep1: TestDepOne by mxo.spy()
+  private val dep2: TestDepTwo by mxo.mock()
+
+  @Test fun testObjectTypes() {
+    assertThat(realObject).all {
+      isNotMock()
+
+      prop(TestObj::dep1).all {
+        isSpy()
+        isEqualTo(dep1)
+
+        prop(TestDepOne::dep2).all {
+          isMock()
+          isNotSpy()
+          isEqualTo(dep2)
+        }
+      }
+    }
+  }
+
+  @Test fun testCanCallMockFunctions() {
+    realObject.dep1.doSomething()
+
+    inOrder(dep1, dep2) {
+      verify(dep1).doSomething()
+      verify(dep2).touch()
+    }
+  }
+
+  private class TestDepOne(val dep2: TestDepTwo) {
+    fun doSomething() {
+      dep2.touch()
+    }
+  }
+
+  private interface TestDepTwo {
+    fun touch()
+  }
+
+  private class TestObj(val dep1: TestDepOne)
+}

--- a/plugins/mockito/src/test/kotlin/com/episode6/mxo2/plugins/mockito/TestExt.kt
+++ b/plugins/mockito/src/test/kotlin/com/episode6/mxo2/plugins/mockito/TestExt.kt
@@ -6,3 +6,5 @@ import org.mockito.internal.util.MockUtil
 
 fun <T:Any> Assert<T>.isMock() = matchesPredicate { MockUtil.isMock(it) }
 fun <T:Any> Assert<T>.isNotMock() = matchesPredicate { !MockUtil.isMock(it) }
+fun <T:Any> Assert<T>.isSpy() = matchesPredicate { MockUtil.isSpy(it) }
+fun <T:Any> Assert<T>.isNotSpy() = matchesPredicate { !MockUtil.isSpy(it) }


### PR DESCRIPTION
Updates the realObject/realImpl methods to accept an interceptor lambda. This lambda allows test code to wrap a real object created by mockspresso before it gets cached or injected into other objects.

The driver behind this logic is to support the `MockspressoProperties.spy` extension, which lets mockspresso create a real object for us but then we wrap it with a mockito (or mockk) spy.