### PR TITLE
Make all dependencies potentially dynamic

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -1,5 +1,6 @@
 package com.episode6.mxo2
 
+import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.api.DynamicObjectMaker
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.api.ObjectMaker
@@ -33,7 +34,7 @@ interface MockspressoBuilder {
 
   fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder // formerly special object makers
 
-  fun <T : Any?> addDependencyOf(key: DependencyKey<T>, provider: () -> T): MockspressoBuilder
+  fun <T : Any?> addDependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder
   fun <BIND : Any?, IMPL : BIND> useRealImplOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
@@ -54,7 +55,7 @@ interface MockspressoInstance {
 interface MockspressoProperties {
   fun onSetup(cmd: (MockspressoInstance) -> Unit)
   fun onTeardown(cmd: () -> Unit)
-  fun <T : Any?> depOf(key: DependencyKey<T>, maker: () -> T): Lazy<T>
+  fun <T : Any?> depOf(key: DependencyKey<T>, maker: Dependencies.() -> T): Lazy<T>
   fun <T : Any?> findDepOf(key: DependencyKey<T>): Lazy<T>
   fun <BIND : Any?, IMPL : BIND> realImplOf(
     key: DependencyKey<BIND>,

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -1,18 +1,26 @@
 package com.episode6.mxo2
 
+import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.reflect.dependencyKey
 import com.episode6.mxo2.reflect.typeToken
-import kotlin.coroutines.ContinuationInterceptor
 
-inline fun <reified T : Any?> MockspressoBuilder.addDependencyOf(qualifier: Annotation? = null, noinline provider: () -> T): MockspressoBuilder =
+inline fun <reified T : Any?> MockspressoBuilder.addDependencyOf(
+  qualifier: Annotation? = null,
+  noinline provider: Dependencies.() -> T
+): MockspressoBuilder =
   addDependencyOf(dependencyKey(qualifier), provider)
 
-inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(qualifier: Annotation? = null, noinline interceptor: (T)->T = {it}): MockspressoBuilder =
+inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(
+  qualifier: Annotation? = null,
+  noinline interceptor: (T) -> T = { it }
+): MockspressoBuilder =
   dependencyKey<T>(qualifier).let { useRealImplOf(it, it.token, interceptor) }
 
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.useRealImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->BIND = {it}): MockspressoBuilder =
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.useRealImplOf(
+  qualifier: Annotation? = null,
+  noinline interceptor: (IMPL) -> BIND = { it }
+): MockspressoBuilder =
   useRealImplOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
-
 
 
 inline fun <reified T : Any?> MockspressoInstance.createRealObject(qualifier: Annotation? = null): T =
@@ -22,15 +30,23 @@ inline fun <reified T : Any?> MockspressoInstance.findDependency(qualifier: Anno
   findDependency(dependencyKey(qualifier))
 
 
-
-inline fun <reified T : Any?> MockspressoProperties.depOf(qualifier: Annotation? = null, noinline provider: () -> T): Lazy<T> =
+inline fun <reified T : Any?> MockspressoProperties.depOf(
+  qualifier: Annotation? = null,
+  noinline provider: Dependencies.() -> T
+): Lazy<T> =
   depOf(dependencyKey(qualifier), provider)
 
 inline fun <reified T : Any?> MockspressoProperties.findDep(qualifier: Annotation? = null): Lazy<T> =
   findDepOf(dependencyKey(qualifier))
 
-inline fun <reified T : Any?> MockspressoProperties.realInstance(qualifier: Annotation? = null, noinline interceptor: (T)->T = {it}): Lazy<T> =
+inline fun <reified T : Any?> MockspressoProperties.realInstance(
+  qualifier: Annotation? = null,
+  noinline interceptor: (T) -> T = { it }
+): Lazy<T> =
   dependencyKey<T>(qualifier).let { realImplOf(it, it.token, interceptor) }
 
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(qualifier: Annotation? = null, noinline interceptor: (IMPL)->IMPL = {it}): Lazy<IMPL> =
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(
+  qualifier: Annotation? = null,
+  noinline interceptor: (IMPL) -> IMPL = { it }
+): Lazy<IMPL> =
   realImplOf(dependencyKey<BIND>(qualifier), typeToken(), interceptor)

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
@@ -18,10 +18,10 @@ internal class DependencyCacheBuilder {
   @Suppress("UNCHECKED_CAST")
   fun build(makeDependencies: DependencyValidator.() -> Dependencies): DependencyCache {
     val cache = DependencyCache()
-    map.entries.forEach { (key, maker) ->
+    map.entries.forEach { (key, makeObject) ->
       key as DependencyKey<Any?>
       val validator = DependencyValidator(key)
-      cache.put(key, validator) { validator.makeDependencies().maker() }
+      cache.put(key, validator) { validator.makeDependencies().makeObject() }
     }
     return cache
   }

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
@@ -1,0 +1,28 @@
+package com.episode6.mxo2.internal
+
+import com.episode6.mxo2.api.Dependencies
+import com.episode6.mxo2.reflect.DependencyKey
+
+private typealias Maker<T> = Dependencies.() -> T
+
+internal class DependencyCacheBuilder {
+  private val map: MutableMap<DependencyKey<*>, Maker<*>> = mutableMapOf()
+
+  fun containsKey(key: DependencyKey<*>): Boolean = map.containsKey(key)
+
+  fun <T : Any?> put(key: DependencyKey<T>, maker: Dependencies.() -> T) {
+    map[key] = maker
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  fun build(makeDependencies: (DependencyValidator)->Dependencies): DependencyCache {
+    val cache = DependencyCache()
+    map.entries.forEach { (key, maker) ->
+      key as DependencyKey<Any?>
+      val validator = DependencyValidator(key)
+      val dependencies = { makeDependencies(validator) }
+      cache.put(key, validator) { dependencies().maker() }
+    }
+    return cache
+  }
+}

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
@@ -15,13 +15,12 @@ internal class DependencyCacheBuilder {
   }
 
   @Suppress("UNCHECKED_CAST")
-  fun build(makeDependencies: (DependencyValidator)->Dependencies): DependencyCache {
+  fun build(makeDependencies: DependencyValidator.()->Dependencies): DependencyCache {
     val cache = DependencyCache()
     map.entries.forEach { (key, maker) ->
       key as DependencyKey<Any?>
       val validator = DependencyValidator(key)
-      val dependencies = { makeDependencies(validator) }
-      cache.put(key, validator) { dependencies().maker() }
+      cache.put(key, validator) { validator.makeDependencies().maker() }
     }
     return cache
   }

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/DependencyCacheBuilder.kt
@@ -5,6 +5,7 @@ import com.episode6.mxo2.reflect.DependencyKey
 
 private typealias Maker<T> = Dependencies.() -> T
 
+// stores dependency cache "requests" until the MxoInstance is constructed
 internal class DependencyCacheBuilder {
   private val map: MutableMap<DependencyKey<*>, Maker<*>> = mutableMapOf()
 
@@ -15,7 +16,7 @@ internal class DependencyCacheBuilder {
   }
 
   @Suppress("UNCHECKED_CAST")
-  fun build(makeDependencies: DependencyValidator.()->Dependencies): DependencyCache {
+  fun build(makeDependencies: DependencyValidator.() -> Dependencies): DependencyCache {
     val cache = DependencyCache()
     map.entries.forEach { (key, maker) ->
       key as DependencyKey<Any?>

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -1,6 +1,7 @@
 package com.episode6.mxo2.internal
 
 import com.episode6.mxo2.*
+import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.api.DynamicObjectMaker
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.api.ObjectMaker
@@ -34,7 +35,7 @@ internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : 
   override fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker): MockspressoBuilder =
     apply { builder.fallbackObjectMaker(fallbackMaker) }
 
-  override fun <T> addDependencyOf(key: DependencyKey<T>, provider: () -> T): MockspressoBuilder =
+  override fun <T> addDependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder =
     apply { builder.dependencyOf(key, provider) }
 
   override fun <BIND : Any?, IMPL : BIND>  useRealImplOf(
@@ -70,10 +71,9 @@ private class MockspressoPropertiesContainer(
     builder.onTearDown(cmd)
   }
 
-  override fun <T> depOf(key: DependencyKey<T>, maker: () -> T): Lazy<T> {
-    val lazy = mlazy(maker)
-    builder.dependencyOf(key) { lazy.value }
-    return lazy
+  override fun <T> depOf(key: DependencyKey<T>, maker: Dependencies.() -> T): Lazy<T> {
+    builder.dependencyOf(key, maker)
+    return findDepOf(key)
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
@@ -16,9 +16,11 @@ internal class MxoInstance(
   private val dynamicMakers: List<DynamicObjectMaker>,
   setupCallbacks: MutableList<(MockspressoInstance) -> Unit>,
   private val teardownCallbacks: List<() -> Unit>,
-  private val dependencies: DependencyCache,
+  dependenciesBuilder: DependencyCacheBuilder,
   private val realObjectRequests: RealObjectRequestsList,
 ) {
+
+  private val dependencies = dependenciesBuilder.build { it.asDependencies() }
 
   val ensureInit: () -> Unit by runOnce {
     parent?.ensureInit?.invoke()

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstance.kt
@@ -20,7 +20,7 @@ internal class MxoInstance(
   private val realObjectRequests: RealObjectRequestsList,
 ) {
 
-  private val dependencies = dependenciesBuilder.build { it.asDependencies() }
+  private val dependencies = dependenciesBuilder.build { asDependencies() }
 
   val ensureInit: () -> Unit by runOnce {
     parent?.ensureInit?.invoke()

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstanceBuilder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MxoInstanceBuilder.kt
@@ -2,6 +2,7 @@ package com.episode6.mxo2.internal
 
 import com.episode6.mxo2.DependencyAlreadyMappedError
 import com.episode6.mxo2.MockspressoInstance
+import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.api.ObjectMaker
 import com.episode6.mxo2.api.DynamicObjectMaker
@@ -17,7 +18,7 @@ internal class MxoInstanceBuilder(private val parent: Lazy<MxoInstance>? = null)
 
   private val dynamicMakers: MutableList<DynamicObjectMaker> = mutableListOf()
 
-  private val dependencies = DependencyCache()
+  private val dependencies = DependencyCacheBuilder()
   private val realObjectRequests = RealObjectRequestsList()
 
   private val setupCallbacks: MutableList<(MockspressoInstance) -> Unit> = mutableListOf()
@@ -43,9 +44,9 @@ internal class MxoInstanceBuilder(private val parent: Lazy<MxoInstance>? = null)
     this.fallbackMaker = fallbackMaker
   }
 
-  fun <T : Any?> dependencyOf(key: DependencyKey<T>, provider: () -> T) {
+  fun <T : Any?> dependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T) {
     key.assertNotMapped()
-    dependencies.put(key, DependencyValidator(key), provider)
+    dependencies.put(key, provider)
   }
 
   fun <BIND : Any?, IMPL : BIND> realObject(
@@ -71,7 +72,7 @@ internal class MxoInstanceBuilder(private val parent: Lazy<MxoInstance>? = null)
       dynamicMakers = dynamicMakers,
       setupCallbacks = setupCallbacks,
       teardownCallbacks = teardownCallbacks,
-      dependencies = dependencies,
+      dependenciesBuilder = dependencies,
       realObjectRequests = realObjectRequests,
     )
   }

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
 import assertk.assertions.isNotNull
+import com.episode6.mxo2.reflect.dependencyKey
 import kotlin.test.Test
 
 class CircularDependencyTest {
@@ -32,6 +33,19 @@ class CircularDependencyTest {
 
     assertThat(c.a).isNotNull()
     assertThat(c.a!!.b).isEqualTo(b)
+  }
+
+  @Test fun testCircularDependency_stillFailsOnDynamicDependency() {
+    val mxo = MockspressoBuilder()
+      .useRealInstanceOf<A?>()
+      .addDependencyOf<B?> { B(get(dependencyKey())) }
+      .build()
+
+    val c by mxo.realImplOf<C?, C>()
+
+    assertThat {
+      c.a
+    }.isFailure().hasClass(CircularDependencyError::class)
   }
 
   private class A(val b: B?)

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.episode6.mxo2
 
 import assertk.assertThat
 import assertk.assertions.*
+import com.episode6.mxo2.reflect.dependencyKey
 import io.mockk.spyk
 import io.mockk.verify
 import kotlin.test.Test
@@ -101,6 +102,30 @@ class SimpleIntegrationTest {
     assertThat(dep2).isEqualTo(objUnderTest.dependency2)
     objUnderTest.dependency2.doSomething()
     verify { dep2.doSomething() }
+  }
+
+  @Test fun testDynamicDependency() {
+    val mxo = MockspressoBuilder()
+      .addDependencyOf { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+      .build()
+
+    val dep1 by mxo.depOf { SomeDependency1() }
+    val dep2 by mxo.depOf { SomeDependency2() }
+    val someObject: SomeObject by mxo.findDep()
+
+    assertThat(someObject.dependency1).isEqualTo(dep1)
+    assertThat(someObject.dependency2).isEqualTo(dep2)
+  }
+
+  @Test fun testDynamicDependencyInProp() {
+    val mxo = MockspressoBuilder().build()
+
+    val someObject by mxo.depOf { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+    val dep1 by mxo.depOf { SomeDependency1() }
+    val dep2 by mxo.depOf { SomeDependency2() }
+
+    assertThat(someObject.dependency1).isEqualTo(dep1)
+    assertThat(someObject.dependency2).isEqualTo(dep2)
   }
 
   private class SomeObject(val dependency1: SomeDependency1, val dependency2: SomeDependency2) {


### PR DESCRIPTION
Update the dependency provider lambda to include `Dependencies` as the receiver. This means any single dependency declaration could potentially be dynamic.