### PR TITLE
Add mockk plugin module

### DIFF
--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -180,14 +180,14 @@ inline fun <reified T : Any?> MockspressoProperties.mock(
 }
 
 /**
- * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be par of the mockspresso
+ * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be part of the mockspresso
  * graph and can be used by other real objects (and then verified in test code).
  */
 inline fun <reified T : Any?> MockspressoProperties.spy(qualifier: Annotation? = null): Lazy<T> =
   realInstance(qualifier) { spy(it) }
 
 /**
- * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be par of the mockspresso
+ * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be part of the mockspresso
  * graph and can be used by other real objects (and then verified in test code). The [stubbing] will be applied to the
  * spy before it is injected as a dependency into other classes.
  */
@@ -198,7 +198,7 @@ inline fun <reified T : Any?> MockspressoProperties.spy(
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
- * using type [BIND]). This spy will be par of the mockspresso graph and can be used by other real objects
+ * using type [BIND]). This spy will be part of the mockspresso graph and can be used by other real objects
  * (and then verified in test code).
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
@@ -206,7 +206,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyI
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
- * using type [BIND]). This spy will be par of the mockspresso graph and can be used by other real objects
+ * using type [BIND]). This spy will be part of the mockspresso graph and can be used by other real objects
  * (and then verified in test code). The [stubbing] will be applied to the spy before it is injected as a dependency
  * into other classes.
  */

--- a/plugins/mockk/build.gradle.kts
+++ b/plugins/mockk/build.gradle.kts
@@ -1,4 +1,4 @@
-description = "Mockk support for Mockspresso2"
+description = "Mockk support for Mockspresso2."
 
 plugins {
   id("config-multi-deploy")

--- a/plugins/mockk/build.gradle.kts
+++ b/plugins/mockk/build.gradle.kts
@@ -1,0 +1,21 @@
+description = "Mockk support for Mockspresso2"
+
+plugins {
+  id("config-multi-deploy")
+}
+
+kotlin {
+  sourceSets {
+    val commonMain by getting {
+      dependencies {
+        api(project(":api"))
+        implementation(libs.mockk.core)
+      }
+    }
+    val commonTest by getting {
+      dependencies {
+        implementation(project(":core"))
+      }
+    }
+  }
+}

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -30,7 +30,13 @@ fun MockspressoBuilder.fallbackWithMockk(
   }
 })
 
-
+/**
+ * Add a mockk with the supplied params as a dependency in this mockspresso instance. Mock will be bound with the
+ * supplied qualifier annotation. If you need a reference to the mock dependency, consider [MockspressoProperties.mockk]
+ * instead.
+ *
+ * IMPORTANT: we default [relaxed] and [relaxUnitFun] to true for defaultMocks.
+ */
 inline fun <reified T : Any?> MockspressoBuilder.defaultMockk(
   qualifier: Annotation? = null,
   name: String? = null,
@@ -48,6 +54,10 @@ inline fun <reified T : Any?> MockspressoBuilder.defaultMockk(
   )
 }
 
+/**
+ * Add a mockk with the supplied params as a dependency in this mockspresso instance. Mockk will be bound with the
+ * supplied qualifier annotation and will be accessible via the returned lazy.
+ */
 inline fun <reified T : Any?> MockspressoProperties.mockk(
   qualifier: Annotation? = null,
   name: String? = null,
@@ -65,6 +75,10 @@ inline fun <reified T : Any?> MockspressoProperties.mockk(
   )
 }
 
+/**
+ * Create a real object of [T] using mockspresso then wrap it in a [spyk]. This spy will be part of the mockspresso
+ * graph and can be used by other real objects (and then verified in test code).
+ */
 inline fun <reified T : Any?> MockspressoProperties.spyk(
   qualifier: Annotation? = null,
   name: String? = null,
@@ -81,6 +95,11 @@ inline fun <reified T : Any?> MockspressoProperties.spyk(
   )
 }
 
+/**
+ * Create a real object of type [IMPL] using mockspresso then wrap it in a [spyk] (the object will be bound
+ * using type [BIND]). This spy will be part of the mockspresso graph and can be used by other real objects
+ * (and then verified in test code).
+ */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spykImplOf(
   qualifier: Annotation? = null,
   name: String? = null,

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -1,11 +1,14 @@
 package com.episode6.mxo2.plugins.mockk
 
-import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.*
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.asKClass
 import io.mockk.MockK
 import io.mockk.MockKGateway
+import kotlin.reflect.KClass
+import io.mockk.mockk as _mockk
+import io.mockk.spyk as _spyk
 
 /**
  * Use mockk to generate fallback objects for dependencies that are not present in the mockspresso instance
@@ -26,3 +29,70 @@ fun MockspressoBuilder.fallbackWithMockk(
     ) as T
   }
 })
+
+
+inline fun <reified T : Any?> MockspressoBuilder.defaultMockk(
+  qualifier: Annotation? = null,
+  name: String? = null,
+  relaxed: Boolean = true,
+  vararg moreInterfaces: KClass<*>,
+  relaxUnitFun: Boolean = true,
+  noinline block: T.() -> Unit = {}
+) = addDependencyOf<T>(qualifier) {
+  _mockk(
+    name = name,
+    relaxed = relaxed,
+    moreInterfaces = *moreInterfaces,
+    relaxUnitFun = relaxUnitFun,
+    block = block
+  )
+}
+
+inline fun <reified T : Any?> MockspressoProperties.mockk(
+  qualifier: Annotation? = null,
+  name: String? = null,
+  relaxed: Boolean = false,
+  vararg moreInterfaces: KClass<*>,
+  relaxUnitFun: Boolean = false,
+  noinline block: T.() -> Unit = {}
+): Lazy<T> = depOf<T>(qualifier) {
+  _mockk(
+    name = name,
+    relaxed = relaxed,
+    moreInterfaces = *moreInterfaces,
+    relaxUnitFun = relaxUnitFun,
+    block = block
+  )
+}
+
+inline fun <reified T : Any?> MockspressoProperties.spyk(
+  qualifier: Annotation? = null,
+  name: String? = null,
+  vararg moreInterfaces: KClass<*>,
+  recordPrivateCalls: Boolean = false,
+  noinline block: T.() -> Unit = {}
+): Lazy<T> = realInstance<T>(qualifier) {
+  _spyk(
+    objToCopy = it!!,
+    name = name,
+    moreInterfaces = *moreInterfaces,
+    recordPrivateCalls = recordPrivateCalls,
+    block = block,
+  )
+}
+
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spykImplOf(
+  qualifier: Annotation? = null,
+  name: String? = null,
+  vararg moreInterfaces: KClass<*>,
+  recordPrivateCalls: Boolean = false,
+  noinline block: IMPL.() -> Unit = {}
+): Lazy<IMPL> = realImplOf<BIND, IMPL>(qualifier) {
+  _spyk(
+    objToCopy = it!!,
+    name = name,
+    moreInterfaces = *moreInterfaces,
+    recordPrivateCalls = recordPrivateCalls,
+    block = block,
+  )
+}

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -1,0 +1,24 @@
+package com.episode6.mxo2.plugins.mockk
+
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.api.FallbackObjectMaker
+import com.episode6.mxo2.reflect.DependencyKey
+import com.episode6.mxo2.reflect.asKClass
+import io.mockk.MockKGateway
+
+/**
+ * Use mockk to generate fallback objects
+ */
+@Suppress("UNCHECKED_CAST")
+fun MockspressoBuilder.fallbackWithMockk(
+  relaxed: Boolean = true,
+  relaxedUnitFun: Boolean = true,
+): MockspressoBuilder = makeFallbackObjectsWith(object : FallbackObjectMaker {
+  override fun <T> makeObject(key: DependencyKey<T>): T = MockKGateway.implementation().mockFactory.mockk(
+    mockType = key.token.asKClass(),
+    name = "automock:$key",
+    relaxed = relaxed,
+    moreInterfaces = emptyArray(),
+    relaxUnitFun = relaxedUnitFun,
+  ) as T
+})

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -8,7 +8,7 @@ import io.mockk.MockK
 import io.mockk.MockKGateway
 
 /**
- * Use mockk to generate fallback objects
+ * Use mockk to generate fallback objects for dependencies that are not present in the mockspresso instance
  */
 @Suppress("UNCHECKED_CAST")
 fun MockspressoBuilder.fallbackWithMockk(

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -4,6 +4,7 @@ import com.episode6.mxo2.MockspressoBuilder
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.asKClass
+import io.mockk.MockK
 import io.mockk.MockKGateway
 
 /**
@@ -14,11 +15,14 @@ fun MockspressoBuilder.fallbackWithMockk(
   relaxed: Boolean = true,
   relaxedUnitFun: Boolean = true,
 ): MockspressoBuilder = makeFallbackObjectsWith(object : FallbackObjectMaker {
-  override fun <T> makeObject(key: DependencyKey<T>): T = MockKGateway.implementation().mockFactory.mockk(
-    mockType = key.token.asKClass(),
-    name = "automock:$key",
-    relaxed = relaxed,
-    moreInterfaces = emptyArray(),
-    relaxUnitFun = relaxedUnitFun,
-  ) as T
+  // we're duplicating internal mockk code here to support creating generic mocks based on a [DependencyKey]
+  override fun <T> makeObject(key: DependencyKey<T>): T = MockK.useImpl {
+    MockKGateway.implementation().mockFactory.mockk(
+      mockType = key.token.asKClass(),
+      name = "automock:$key",
+      relaxed = relaxed,
+      moreInterfaces = emptyArray(),
+      relaxUnitFun = relaxedUnitFun,
+    ) as T
+  }
 })

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
@@ -13,7 +13,6 @@ class MockkFallbackMakerTest {
 
   private val realObject: TestObj by mxo.realInstance()
 
-
   @Test fun testCanCallMockFunctions() {
     realObject.dep1.doSomething()
     realObject.dep2.doSomethingElse()

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
@@ -2,6 +2,7 @@ package com.episode6.mxo2.plugins.mockk
 
 import com.episode6.mxo2.MockspressoBuilder
 import com.episode6.mxo2.realInstance
+import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlin.test.Test
 
@@ -12,6 +13,7 @@ class MockkFallbackMakerTest {
     .build()
 
   private val realObject: TestObj by mxo.realInstance()
+  private val realObjectWithNullable: TestObjNullable by mxo.realInstance()
 
   @Test fun testCanCallMockFunctions() {
     realObject.dep1.doSomething()
@@ -23,6 +25,12 @@ class MockkFallbackMakerTest {
     }
   }
 
+  @Test fun testCanCallMockOnNullableDep() {
+    realObjectWithNullable.nullableDep!!.doSomethingElse()
+    
+    verify { realObjectWithNullable.nullableDep!!.doSomethingElse() }
+  }
+
   private class TestDepOne {
     fun doSomething() {}
   }
@@ -32,4 +40,5 @@ class MockkFallbackMakerTest {
   }
 
   private class TestObj(val dep1: TestDepOne, val dep2: TestDepTwo)
+  private class TestObjNullable(val nullableDep: TestDepTwo?)
 }

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkFallbackMakerTest.kt
@@ -1,0 +1,36 @@
+package com.episode6.mxo2.plugins.mockk
+
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.realInstance
+import io.mockk.verifyOrder
+import kotlin.test.Test
+
+class MockkFallbackMakerTest {
+
+  val mxo = MockspressoBuilder()
+    .fallbackWithMockk()
+    .build()
+
+  private val realObject: TestObj by mxo.realInstance()
+
+
+  @Test fun testCanCallMockFunctions() {
+    realObject.dep1.doSomething()
+    realObject.dep2.doSomethingElse()
+
+    verifyOrder {
+      realObject.dep1.doSomething()
+      realObject.dep2.doSomethingElse()
+    }
+  }
+
+  private class TestDepOne {
+    fun doSomething() {}
+  }
+
+  private interface TestDepTwo {
+    fun doSomethingElse()
+  }
+
+  private class TestObj(val dep1: TestDepOne, val dep2: TestDepTwo)
+}

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkMockingTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkMockingTest.kt
@@ -2,13 +2,11 @@ package com.episode6.mxo2.plugins.mockk
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.hasClass
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFailure
-import assertk.assertions.prop
+import assertk.assertions.*
 import com.episode6.mxo2.MockspressoBuilder
 import com.episode6.mxo2.realInstance
 import io.mockk.every
+import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlin.test.Test
 
@@ -22,6 +20,9 @@ class MockkMockingTest {
 
   private val realObject: TestObj by mxo.realInstance()
   private val dep2: TestDepTwo by mxo.mockk(relaxed = true)
+
+  private val realWithNullable: TestObjNullable by mxo.realInstance()
+  private val nullableDep2: TestDepTwo? by mxo.mockk(relaxed = true)
 
   @Test fun testFallbackHasMocks() {
     assertThat(realObject.dep2).isEqualTo(dep2)
@@ -39,6 +40,18 @@ class MockkMockingTest {
     }
   }
 
+  @Test fun testCanCallMockFunctionsOnNullable() {
+    realWithNullable.nullableDep!!.doSomethingElse()
+
+    verify {
+      nullableDep2!!.doSomethingElse()
+    }
+    assertThat(realWithNullable.nullableDep).all {
+      isNotNull()
+      isEqualTo(nullableDep2)
+    }
+  }
+
   private class TestDepOne {
     fun doSomething() {}
   }
@@ -48,4 +61,5 @@ class MockkMockingTest {
   }
 
   private class TestObj(val dep1: TestDepOne, val dep2: TestDepTwo)
+  private class TestObjNullable(val nullableDep: TestDepTwo?)
 }

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkMockingTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkMockingTest.kt
@@ -1,0 +1,51 @@
+package com.episode6.mxo2.plugins.mockk
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.prop
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.realInstance
+import io.mockk.every
+import io.mockk.verifyOrder
+import kotlin.test.Test
+
+class MockkMockingTest {
+
+  val mxo = MockspressoBuilder()
+    .defaultMockk<TestDepOne> {
+      every { doSomething() } throws RuntimeException()
+    }
+    .build()
+
+  private val realObject: TestObj by mxo.realInstance()
+  private val dep2: TestDepTwo by mxo.mockk(relaxed = true)
+
+  @Test fun testFallbackHasMocks() {
+    assertThat(realObject.dep2).isEqualTo(dep2)
+  }
+
+  @Test fun testCanCallMockFunctions() {
+    assertThat { realObject.dep1.doSomething() }
+      .isFailure()
+      .hasClass(RuntimeException::class)
+    realObject.dep2.doSomethingElse()
+
+    verifyOrder {
+      realObject.dep1.doSomething()
+      dep2.doSomethingElse()
+    }
+  }
+
+  private class TestDepOne {
+    fun doSomething() {}
+  }
+
+  private interface TestDepTwo {
+    fun doSomethingElse()
+  }
+
+  private class TestObj(val dep1: TestDepOne, val dep2: TestDepTwo)
+}

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkSpyingTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mxo2/plugins/mockk/MockkSpyingTest.kt
@@ -1,0 +1,51 @@
+package com.episode6.mxo2.plugins.mockk
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.realInstance
+import io.mockk.verifyOrder
+import kotlin.test.Test
+
+class MockkSpyingTest {
+
+  val mxo = MockspressoBuilder().build()
+
+  private val realObject: TestObj by mxo.realInstance()
+  private val dep1: TestDepOne by mxo.spyk()
+  private val dep2: TestDepTwo by mxo.mockk(relaxed = true)
+
+  @Test fun testObjectTypes() {
+    assertThat(realObject).all {
+      prop(TestObj::dep1).all {
+        isEqualTo(dep1)
+        prop(TestDepOne::dep2).all {
+          isEqualTo(dep2)
+        }
+      }
+    }
+  }
+
+  @Test fun testCanCallMockFunctions() {
+    realObject.dep1.doSomething()
+
+    verifyOrder {
+      dep1.doSomething()
+      dep2.touch()
+    }
+  }
+
+  private class TestDepOne(val dep2: TestDepTwo) {
+    fun doSomething() {
+      dep2.touch()
+    }
+  }
+
+  private interface TestDepTwo {
+    fun touch()
+  }
+
+  private class TestObj(val dep1: TestDepOne)
+}

--- a/plugins/settings.gradle.kts
+++ b/plugins/settings.gradle.kts
@@ -4,6 +4,7 @@ listOf(
   "junit4",
   "junit5",
   "mockito",
+  "mockk",
 ).forEach {
   include("$prefix-$it")
   project(":$prefix-$it").projectDir = file(it)


### PR DESCRIPTION
Adds a plugin module to support [mockk](https://mockk.io/). Includes fallback maker, `defaultMockk`, `mockk` and `spyk` extension methods.