### PR TITLE
Add javax MockspressoInstance.inject extensions

### DIFF
--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
@@ -1,6 +1,10 @@
 package com.episode6.mxo2.plugins.javax.inject
 
 import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.MockspressoInstance
+import com.episode6.mxo2.api.Dependencies
+import com.episode6.mxo2.reflect.DependencyKey
+import com.episode6.mxo2.reflect.TypeToken
 
 /**
  * Make real objects using reflection according to java.inject rules. Supports constructor, property, field and
@@ -13,3 +17,8 @@ fun MockspressoBuilder.makeRealObjectsUsingJavaxInjectRules(): MockspressoBuilde
  * Enable automatic mapping of [javax.inject.Provider]s to their underlying dependencies.
  */
 fun MockspressoBuilder.javaxProviderSupport(): MockspressoBuilder = addDynamicObjectMaker(javaxProviderMaker())
+
+fun MockspressoInstance.inject(obj: Any) {
+  val key = DependencyKey(TypeToken())
+  obj.injectProperties(obj)
+}

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
@@ -2,8 +2,6 @@ package com.episode6.mxo2.plugins.javax.inject
 
 import com.episode6.mxo2.MockspressoBuilder
 import com.episode6.mxo2.MockspressoInstance
-import com.episode6.mxo2.api.Dependencies
-import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.TypeToken
 import kotlin.reflect.full.createType
 
@@ -19,10 +17,20 @@ fun MockspressoBuilder.makeRealObjectsUsingJavaxInjectRules(): MockspressoBuilde
  */
 fun MockspressoBuilder.javaxProviderSupport(): MockspressoBuilder = addDynamicObjectMaker(javaxProviderMaker())
 
+/**
+ * Perform field and method injection on an object that's been created outside the context of mockspresso.
+ *
+ * WARNING: this method will throw an [IllegalArgumentException] immediately if [instance] is not a concrete class.
+ * To inject generics use the alternate signature of [inject] that accepts a [TypeToken]
+ */
 fun MockspressoInstance.inject(instance: Any) {
   inject(instance, TypeToken(instance.javaClass.kotlin.createType()))
 }
 
-fun <T: Any> MockspressoInstance.inject(instance: T, token: TypeToken<T>) {
+/**
+ * Perform field and method injection on an object that's been created outside the context of mockspresso. This method
+ * is safe to use with generic objects
+ */
+fun <T : Any> MockspressoInstance.inject(instance: T, token: TypeToken<T>) {
   instance.injectWithDependencies(token, asDependencies())
 }

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
@@ -5,6 +5,7 @@ import com.episode6.mxo2.MockspressoInstance
 import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.TypeToken
+import kotlin.reflect.full.createType
 
 /**
  * Make real objects using reflection according to java.inject rules. Supports constructor, property, field and
@@ -18,7 +19,10 @@ fun MockspressoBuilder.makeRealObjectsUsingJavaxInjectRules(): MockspressoBuilde
  */
 fun MockspressoBuilder.javaxProviderSupport(): MockspressoBuilder = addDynamicObjectMaker(javaxProviderMaker())
 
-fun MockspressoInstance.inject(obj: Any) {
-  val key = DependencyKey(TypeToken())
-  obj.injectProperties(obj)
+fun MockspressoInstance.inject(instance: Any) {
+  inject(instance, TypeToken(instance.javaClass.kotlin.createType()))
+}
+
+fun <T: Any> MockspressoInstance.inject(instance: T, token: TypeToken<T>) {
+  instance.injectWithDependencies(token, asDependencies())
 }

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxRealObjectMaker.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxRealObjectMaker.kt
@@ -34,10 +34,8 @@ fun javaxRealObjectMaker(
 ): ObjectMaker {
   val reflectMaker = reflectionRealObjectMaker(chooseConstructor)
   return ObjectMaker { objKey, dependencies ->
-    // use a [reflectionRealObjectMaker] to create the objects, then inject members before it's returned
-    reflectMaker.makeObject(objKey, dependencies).also { obj ->
-      obj?.injectProperties(objKey, dependencies, isInjectProperty, isInjectField)
-      obj?.injectFunctions(objKey, dependencies, isInjectFunction)
+    reflectMaker.makeObject(objKey, dependencies)?.also { obj ->
+      obj.injectWithDependencies(objKey.token, dependencies, isInjectProperty, isInjectField, isInjectFunction)
     }
   }
 }
@@ -51,30 +49,24 @@ fun DependencyKey<*>.findExactlyOneInjectConstructor(isInjectConstructor: KAnnot
   }
 }
 
-internal fun Any.injectProperties(
-  key: DependencyKey<*>,
+internal fun Any.injectWithDependencies(
+  token: TypeToken<*>,
   dependencies: Dependencies,
   isInjectProperty: KAnnotationMatcher = defaultKMatcher,
   isInjectField: JAnnotationMatcher = defaultJMatcher,
+  isInjectFunction: KAnnotationMatcher = defaultKMatcher,
 ) {
-  key.token.asKClass().memberProperties.filterIsInstance<KMutableProperty<*>>()
+  token.asKClass().memberProperties.filterIsInstance<KMutableProperty<*>>()
     .filter { it.setter.isInjectProperty() || it.javaField?.isInjectField() == true }
     .forEach { property ->
       property.tryMakeAccessible()
-      val param = dependencies.get(property.returnTypeKey(context = key))
+      val param = dependencies.get(property.returnTypeKey(context = token))
       property.setter.callWith(this, param)
     }
-}
-
-internal fun Any.injectFunctions(
-  key: DependencyKey<*>,
-  dependencies: Dependencies,
-  isInjectFunction: KAnnotationMatcher = defaultKMatcher,
-) {
-  key.token.asKClass().memberFunctions.filter { it.isInjectFunction() }
+  token.asKClass().memberFunctions.filter { it.isInjectFunction() }
     .forEach { function ->
       function.tryMakeAccessible()
-      val params = function.parameterKeys(context = key.token).drop(1).map { dependencies.get(it) }
+      val params = function.parameterKeys(context = token).drop(1).map { dependencies.get(it) }
       function.callWith(this, *params.toTypedArray())
     }
 }
@@ -83,8 +75,8 @@ internal fun MockspressoInstance.asDependencies(): Dependencies = object : Depen
   override fun <T> get(key: DependencyKey<T>): T = findDependency(key)
 }
 
-private fun KCallable<*>.returnTypeKey(context: DependencyKey<*>): DependencyKey<*> = DependencyKey(
-  token = context.token.resolveType(returnType),
+private fun KCallable<*>.returnTypeKey(context: TypeToken<*>): DependencyKey<*> = DependencyKey(
+  token = context.resolveType(returnType),
   qualifier = annotations.findQualifier { "member $name in class $this" }
 )
 

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectTest.kt
@@ -1,0 +1,101 @@
+package com.episode6.mxo2.plugins.javax.inject
+
+import assertk.assertThat
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.depOf
+import com.episode6.mxo2.reflect.typeToken
+import org.junit.jupiter.api.Test
+import javax.inject.Inject
+
+class JavaxInjectTest {
+
+  val mxo = MockspressoBuilder().build()
+
+  private val dep1 by mxo.depOf { Dependency1() }
+  private val dep2 by mxo.depOf { Dependency2() }
+
+  @Test fun testPropertyInject() {
+    val ro = PropertiesInject()
+
+    mxo.inject(ro)
+
+    assertThat(ro.d1).isEqualTo(dep1)
+    assertThat(ro.d2).isEqualTo(dep2)
+  }
+
+  @Test fun testPropertySetInject() {
+    val ro = PropertiesSetInject()
+
+    mxo.inject(ro)
+
+    assertThat(ro.d1).isEqualTo(dep1)
+    assertThat(ro.d2).isEqualTo(dep2)
+  }
+
+  @Test fun testPropertyFieldInject() {
+    val ro = PropertiesFieldInject()
+
+    mxo.inject(ro)
+
+    assertThat(ro.d1).isEqualTo(dep1)
+    assertThat(ro.d2).isEqualTo(dep2)
+  }
+
+  @Test fun testMethodInject() {
+    val ro = MethodInject()
+
+    mxo.inject(ro)
+
+    assertThat(ro.d1).isEqualTo(dep1)
+    assertThat(ro.d2).isEqualTo(dep2)
+  }
+
+  @Test fun testGenericFail() {
+    val ro = GenericInject<Dependency1, Dependency2>()
+
+    assertThat { mxo.inject(ro) }.isFailure().hasClass(IllegalArgumentException::class)
+  }
+
+  @Test fun testGenericSuccess() {
+    val ro = GenericInject<Dependency1, Dependency2>()
+
+    mxo.inject(ro, typeToken())
+
+    assertThat(ro.d1).isEqualTo(dep1)
+    assertThat(ro.d2).isEqualTo(dep2)
+  }
+
+  private class Dependency1
+  private class Dependency2
+  private class PropertiesInject {
+    @Inject lateinit var d1: Dependency1
+    @Inject lateinit var d2: Dependency2
+  }
+
+  private class PropertiesSetInject {
+    @set:Inject lateinit var d1: Dependency1
+    @set:Inject lateinit var d2: Dependency2
+  }
+
+  private class PropertiesFieldInject {
+    @field:Inject lateinit var d1: Dependency1
+    @field:Inject lateinit var d2: Dependency2
+  }
+
+  private class MethodInject {
+    lateinit var d1: Dependency1
+    lateinit var d2: Dependency2
+    @Inject fun doInject(d1: Dependency1, d2: Dependency2) {
+      this.d1 = d1
+      this.d2 = d2
+    }
+  }
+
+  private open class GenericInject<A: Any, B: Any> {
+    @Inject lateinit var d1: A
+    @Inject lateinit var d2: B
+  }
+}


### PR DESCRIPTION
Support inject functionality via an extension method on MockspressoInstance. Comes with the same caveats as it did in v1 (difference method signatures for concrete classes vs generics). This version is a bit more strict about generics in the single-param version, since we can't create the TypeToken in that case.