### PR TITLE
Bump initial version to 2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ tasks.wrapper {
 
 allprojects {
   group = "com.episode6.mockspresso2"
-  version = "0.0.1-SNAPSHOT"
+  version = "2.0.0-SNAPSHOT"
 }
 
 val dokkaDir = "docs/dokka"


### PR DESCRIPTION
It would get pretty confusing to have mockspresso2 with a version lower than 2. 