### PR TITLE
Rename some api methods

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -100,14 +100,14 @@ interface MockspressoBuilder {
   /**
    * Register a dependency provided by [provider], bound in the mockspresso graph with [key].
    */
-  fun <T : Any?> addDependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder
+  fun <T : Any?> dependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder
 
   /**
    * Register a request to create a real object of type [implementationToken] bound in the mockspresso graph with [key].
    * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
    * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
    */
-  fun <BIND : Any?, IMPL : BIND> useRealImplOf(
+  fun <BIND : Any?, IMPL : BIND> realImplementationOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND = { it }

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -38,7 +38,7 @@ interface MockspressoInstance {
    *
    * Calling this method will ensure this [MockspressoInstance] is initialized.
    */
-  fun <T : Any?> createRealObject(key: DependencyKey<T>): T
+  fun <T : Any?> createNow(key: DependencyKey<T>): T
 
   /**
    * Find an existing dependency in this mockspresso instance. If the dependency hasn't been cached or constructed then
@@ -47,7 +47,7 @@ interface MockspressoInstance {
    *
    * Calling this method will ensure this [MockspressoInstance] is initialized.
    */
-  fun <T : Any?> findDependency(key: DependencyKey<T>): T
+  fun <T : Any?> findNow(key: DependencyKey<T>): T
 
   /**
    * Returns a new [MockspressoBuilder] using this Mockspresso instance as a parent.

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -28,10 +28,10 @@ inline fun <reified T : Any?> MockspressoInstance.findDependency(
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
  * type [T] and [qualifier].
  */
-inline fun <reified T : Any?> MockspressoBuilder.addDependencyOf(
+inline fun <reified T : Any?> MockspressoBuilder.dependencyOf(
   qualifier: Annotation? = null,
   noinline provider: Dependencies.() -> T
-): MockspressoBuilder = addDependencyOf(dependencyKey(qualifier), provider)
+): MockspressoBuilder = dependencyOf(dependencyKey(qualifier), provider)
 
 /**
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
@@ -40,10 +40,10 @@ inline fun <reified T : Any?> MockspressoBuilder.addDependencyOf(
  * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
  * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
  */
-inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(
+inline fun <reified T : Any?> MockspressoBuilder.realInstanceOf(
   qualifier: Annotation? = null,
   noinline interceptor: (T) -> T = { it }
-): MockspressoBuilder = dependencyKey<T>(qualifier).let { useRealImplOf(it, it.token, interceptor) }
+): MockspressoBuilder = dependencyKey<T>(qualifier).let { realImplementationOf(it, it.token, interceptor) }
 
 /**
  * Register a request to create a real object of type [IMPL] bound in the mockspresso graph with a dependencyKey made
@@ -52,10 +52,10 @@ inline fun <reified T : Any?> MockspressoBuilder.useRealInstanceOf(
  * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
  * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
  */
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.useRealImplOf(
+inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImplementationOf(
   qualifier: Annotation? = null,
   noinline interceptor: (IMPL) -> BIND = { it }
-): MockspressoBuilder = useRealImplOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
+): MockspressoBuilder = realImplementationOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
 
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -9,9 +9,9 @@ import com.episode6.mxo2.reflect.typeToken
  *
  * Calling this method will ensure this [MockspressoInstance] is initialized.
  */
-inline fun <reified T : Any?> MockspressoInstance.createRealObject(
+inline fun <reified T : Any?> MockspressoInstance.createNow(
   qualifier: Annotation? = null
-): T = createRealObject(dependencyKey(qualifier))
+): T = createNow(dependencyKey(qualifier))
 
 /**
  * Find an existing dependency in this mockspresso instance of type [T] with the provided [qualifier]. If the
@@ -20,9 +20,9 @@ inline fun <reified T : Any?> MockspressoInstance.createRealObject(
  *
  * Calling this method will ensure this [MockspressoInstance] is initialized.
  */
-inline fun <reified T : Any?> MockspressoInstance.findDependency(
+inline fun <reified T : Any?> MockspressoInstance.findNow(
   qualifier: Annotation? = null
-): T = findDependency(dependencyKey(qualifier))
+): T = findNow(dependencyKey(qualifier))
 
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -36,10 +36,10 @@ internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : 
   override fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker): MockspressoBuilder =
     apply { builder.fallbackObjectMaker(fallbackMaker) }
 
-  override fun <T> addDependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder =
+  override fun <T> dependencyOf(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder =
     apply { builder.dependencyOf(key, provider) }
 
-  override fun <BIND : Any?, IMPL : BIND> useRealImplOf(
+  override fun <BIND : Any?, IMPL : BIND> realImplementationOf(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -52,8 +52,8 @@ internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : 
 }
 
 internal class MockspressoInstanceContainer(private val instance: MxoInstance) : MockspressoInstance {
-  override fun <T> findDependency(key: DependencyKey<T>): T = instance.get(key)
-  override fun <T> createRealObject(key: DependencyKey<T>): T = instance.create(key)
+  override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
+  override fun <T> createNow(key: DependencyKey<T>): T = instance.create(key)
   override fun buildUpon(): MockspressoBuilder = MockspressoBuilderContainer(mlazy { instance })
 }
 
@@ -96,8 +96,8 @@ private class MockspressoContainer(
 ) : Mockspresso, MockspressoProperties by properties {
   private val instance get() = instanceLazy.value
   override fun ensureInit() = instance.ensureInit()
-  override fun <T> findDependency(key: DependencyKey<T>): T = instance.get(key)
-  override fun <T> createRealObject(key: DependencyKey<T>): T = instance.create(key)
+  override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
+  override fun <T> createNow(key: DependencyKey<T>): T = instance.create(key)
 
   override fun teardown() {
     instance.teardown()

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
@@ -12,8 +12,8 @@ class CircularDependencyTest {
 
   @Test fun testCircularDependency() {
     val mxo = MockspressoBuilder()
-      .useRealInstanceOf<A?>()
-      .useRealInstanceOf<B?>()
+      .realInstanceOf<A?>()
+      .realInstanceOf<B?>()
       .build()
 
     val c by mxo.realImplOf<C?, C>()
@@ -25,7 +25,7 @@ class CircularDependencyTest {
 
   @Test fun testWorksWhenChainIsBroken() {
     val mxo = MockspressoBuilder()
-      .useRealInstanceOf<A?>()
+      .realInstanceOf<A?>()
       .build()
 
     val b by mxo.depOf<B?> { B(null) }
@@ -37,8 +37,8 @@ class CircularDependencyTest {
 
   @Test fun testCircularDependency_stillFailsOnDynamicDependency() {
     val mxo = MockspressoBuilder()
-      .useRealInstanceOf<A?>()
-      .addDependencyOf<B?> { B(get(dependencyKey())) }
+      .realInstanceOf<A?>()
+      .dependencyOf<B?> { B(get(dependencyKey())) }
       .build()
 
     val c by mxo.realImplOf<C?, C>()

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/GenericDependenciesTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/GenericDependenciesTest.kt
@@ -9,9 +9,9 @@ class GenericDependenciesTest {
 
   @Test fun testSimpleGeneric() {
     val mxo = MockspressoBuilder()
-      .addDependencyOf { 5 }
-      .addDependencyOf { "hello" }
-      .addDependencyOf { 4.2f }
+      .dependencyOf { 5 }
+      .dependencyOf { "hello" }
+      .dependencyOf { 4.2f }
       .build()
 
     val obj = mxo.createRealObject<GenericObj<String, Int, Float>>()
@@ -23,10 +23,10 @@ class GenericDependenciesTest {
 
   @Test fun testGenericWithGeneric() {
     val mxo = MockspressoBuilder()
-      .useRealInstanceOf<GenericObj<Int, Float, Set<String>>>()
-      .addDependencyOf { 5 }
-      .addDependencyOf { setOf("str1", "str2") }
-      .addDependencyOf { 4.2f }
+      .realInstanceOf<GenericObj<Int, Float, Set<String>>>()
+      .dependencyOf { 5 }
+      .dependencyOf { setOf("str1", "str2") }
+      .dependencyOf { 4.2f }
       .build()
 
     val obj = mxo.createRealObject<GenericWithGeneric<Float, Int>>()
@@ -40,11 +40,11 @@ class GenericDependenciesTest {
 
   @Test fun testRidiculousGenerics() {
     val mxo = MockspressoBuilder()
-      .useRealInstanceOf<GenericObj<List<Map<String, Int>>, Map<String, Int>, Set<String>>>()
-      .useRealInstanceOf<GenericWithGeneric<Map<String, Int>, List<Map<String, Int>>>>()
-      .addDependencyOf { setOf("setStr1", "setStr2") }
-      .addDependencyOf { mapOf("str1" to 1) }
-      .addDependencyOf {
+      .realInstanceOf<GenericObj<List<Map<String, Int>>, Map<String, Int>, Set<String>>>()
+      .realInstanceOf<GenericWithGeneric<Map<String, Int>, List<Map<String, Int>>>>()
+      .dependencyOf { setOf("setStr1", "setStr2") }
+      .dependencyOf { mapOf("str1" to 1) }
+      .dependencyOf {
         listOf(
           mapOf("str2" to 2),
           mapOf("str3" to 3)

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/GenericDependenciesTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/GenericDependenciesTest.kt
@@ -14,7 +14,7 @@ class GenericDependenciesTest {
       .dependencyOf { 4.2f }
       .build()
 
-    val obj = mxo.createRealObject<GenericObj<String, Int, Float>>()
+    val obj = mxo.createNow<GenericObj<String, Int, Float>>()
 
     assertThat(obj.a).isEqualTo("hello")
     assertThat(obj.b).isEqualTo(5)
@@ -29,7 +29,7 @@ class GenericDependenciesTest {
       .dependencyOf { 4.2f }
       .build()
 
-    val obj = mxo.createRealObject<GenericWithGeneric<Float, Int>>()
+    val obj = mxo.createNow<GenericWithGeneric<Float, Int>>()
 
     with(obj.child) {
       assertThat(a).isEqualTo(5)
@@ -52,7 +52,7 @@ class GenericDependenciesTest {
       }
       .build()
 
-    val obj = mxo.createRealObject<ConcreteWithGenerics>()
+    val obj = mxo.createNow<ConcreteWithGenerics>()
 
     with(obj.child.child) {
       assertThat(a).isEqualTo(listOf(mapOf("str2" to 2), mapOf("str3" to 3)))

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/LifecycleTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/LifecycleTest.kt
@@ -21,8 +21,8 @@ class LifecycleTest {
   private val mxo = MockspressoBuilder()
     .onSetup(builderSetup)
     .onTeardown(builderTeardown)
-    .addDependencyOf { testDependency1 }
-    .addDependencyOf { testDependency2 }
+    .dependencyOf { testDependency1 }
+    .dependencyOf { testDependency2 }
     .build()
 
   init {

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/RealImplIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/RealImplIntegrationTest.kt
@@ -10,7 +10,7 @@ class RealImplIntegrationTest {
   @Test fun testRealImplOf() {
     val unexpectedTestClass = TestClass()
     val mxo = MockspressoBuilder()
-      .addDependencyOf { unexpectedTestClass }
+      .dependencyOf { unexpectedTestClass }
       .build()
 
     val obj by mxo.realImplOf<TestInterface, TestClass>()

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -75,8 +75,8 @@ class SimpleIntegrationTest {
   @Test fun testCreateRealObjectGetsNewInstances() {
     val mxo = MockspressoBuilder().build()
 
-    val obj1: SomeDependency1 = mxo.createRealObject()
-    val obj2: SomeDependency1 = mxo.createRealObject()
+    val obj1: SomeDependency1 = mxo.createNow()
+    val obj2: SomeDependency1 = mxo.createNow()
 
     assertThat(obj1).isNotEqualTo(obj2)
   }
@@ -84,10 +84,10 @@ class SimpleIntegrationTest {
   @Test fun testCreateRealObjectIsntCachedAsDep() {
     val mxo = MockspressoBuilder().build()
 
-    val obj1: SomeDependency1 = mxo.createRealObject()
+    val obj1: SomeDependency1 = mxo.createNow()
 
     assertThat {
-      mxo.findDependency<SomeDependency1>()
+      mxo.findNow<SomeDependency1>()
     }.isFailure().hasClass(NoFallbackMakerProvidedError::class)
   }
 

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -93,7 +93,7 @@ class SimpleIntegrationTest {
 
   @Test fun testInterceptSpyk() {
     val mxo = MockspressoBuilder()
-      .addDependencyOf { SomeDependency1() }
+      .dependencyOf { SomeDependency1() }
       .build()
 
     val dep2: SomeDependency2 by mxo.realInstance { spyk(it) }
@@ -106,7 +106,7 @@ class SimpleIntegrationTest {
 
   @Test fun testDynamicDependency() {
     val mxo = MockspressoBuilder()
-      .addDependencyOf { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+      .dependencyOf { SomeObject(get(dependencyKey()), get(dependencyKey())) }
       .build()
 
     val dep1 by mxo.depOf { SomeDependency1() }

--- a/docs/PROJECT_SETUP.md
+++ b/docs/PROJECT_SETUP.md
@@ -82,7 +82,7 @@ Instruct your default `MockspressoBuilder()` to require `@Inject` annotations on
 ```
 **Note:** [`Dagger2Rules`](dokka/plugins-dagger2/com.episode6.mxo2.plugins.dagger2/make-real-objects-using-dagger2-rules.html) is a super-set of [`JavaxInjectRules`](dokka/plugins-javax-inject/com.episode6.mxo2.plugins.javax.inject/make-real-objects-using-javax-inject-rules.html) that adds support for constructors with the `@AssistedInject` annotation.
 
-The [`plugins-javax-inject`](dokka/plugins-javax-inject/com.episode6.mxo2.plugins.javax.inject/index.html) module also includes the [`MockspressoInstance.inject(Any)`](dokka/plugins-javax-inject/com.episode6.mxo2.plugins.javax.inject/inject.html) plugin to inject any pre-existing object with field / method injection. Than can be helpful in android development when running robolectric tests on Activities, Services, etc. that must be created by the system. 
+The [`plugins-javax-inject`](dokka/plugins-javax-inject/com.episode6.mxo2.plugins.javax.inject/index.html) module also includes the [`MockspressoInstance.injectNow(Any)`](dokka/plugins-javax-inject/com.episode6.mxo2.plugins.javax.inject/inject-now.html) plugin to inject any pre-existing object with field / method injection. Than can be helpful in android development when running robolectric tests on Activities, Services, etc. that must be created by the system. 
 
 #### Automatic Provider, Lazy and AssistedFactory handling
 

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectPlugins.kt
@@ -24,16 +24,16 @@ fun MockspressoBuilder.javaxProviderSupport(): MockspressoBuilder = addDynamicOb
  * Perform field and method injection on an object that's been created outside the context of mockspresso.
  *
  * WARNING: this method will throw an [IllegalArgumentException] immediately if [instance] is not a concrete class.
- * To inject generics use the alternate signature of [inject] that accepts a [TypeToken]
+ * To inject generics use the alternate signature of [injectNow] that accepts a [TypeToken]
  */
-fun MockspressoInstance.inject(instance: Any) {
-  inject(instance, TypeToken(instance.javaClass.kotlin.createType()))
+fun MockspressoInstance.injectNow(instance: Any) {
+  injectNow(instance, TypeToken(instance.javaClass.kotlin.createType()))
 }
 
 /**
  * Perform field and method injection on an object that's been created outside the context of mockspresso. This method
  * is safe to use with generic objects
  */
-fun <T : Any> MockspressoInstance.inject(instance: T, token: TypeToken<T>) {
+fun <T : Any> MockspressoInstance.injectNow(instance: T, token: TypeToken<T>) {
   instance.injectWithDependencies(token, asDependencies())
 }

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/reflect/JavaxRealObjectMaker.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mxo2/plugins/javax/inject/reflect/JavaxRealObjectMaker.kt
@@ -72,7 +72,7 @@ internal fun Any.injectWithDependencies(
 }
 
 internal fun MockspressoInstance.asDependencies(): Dependencies = object : Dependencies {
-  override fun <T> get(key: DependencyKey<T>): T = findDependency(key)
+  override fun <T> get(key: DependencyKey<T>): T = findNow(key)
 }
 
 private fun KCallable<*>.returnTypeKey(context: TypeToken<*>): DependencyKey<*> = DependencyKey(

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mxo2/plugins/javax/inject/JavaxInjectTest.kt
@@ -20,7 +20,7 @@ class JavaxInjectTest {
   @Test fun testPropertyInject() {
     val ro = PropertiesInject()
 
-    mxo.inject(ro)
+    mxo.injectNow(ro)
 
     assertThat(ro.d1).isEqualTo(dep1)
     assertThat(ro.d2).isEqualTo(dep2)
@@ -29,7 +29,7 @@ class JavaxInjectTest {
   @Test fun testPropertySetInject() {
     val ro = PropertiesSetInject()
 
-    mxo.inject(ro)
+    mxo.injectNow(ro)
 
     assertThat(ro.d1).isEqualTo(dep1)
     assertThat(ro.d2).isEqualTo(dep2)
@@ -38,7 +38,7 @@ class JavaxInjectTest {
   @Test fun testPropertyFieldInject() {
     val ro = PropertiesFieldInject()
 
-    mxo.inject(ro)
+    mxo.injectNow(ro)
 
     assertThat(ro.d1).isEqualTo(dep1)
     assertThat(ro.d2).isEqualTo(dep2)
@@ -47,7 +47,7 @@ class JavaxInjectTest {
   @Test fun testMethodInject() {
     val ro = MethodInject()
 
-    mxo.inject(ro)
+    mxo.injectNow(ro)
 
     assertThat(ro.d1).isEqualTo(dep1)
     assertThat(ro.d2).isEqualTo(dep2)
@@ -56,13 +56,13 @@ class JavaxInjectTest {
   @Test fun testGenericFail() {
     val ro = GenericInject<Dependency1, Dependency2>()
 
-    assertThat { mxo.inject(ro) }.isFailure().hasClass(IllegalArgumentException::class)
+    assertThat { mxo.injectNow(ro) }.isFailure().hasClass(IllegalArgumentException::class)
   }
 
   @Test fun testGenericSuccess() {
     val ro = GenericInject<Dependency1, Dependency2>()
 
-    mxo.inject(ro, typeToken())
+    mxo.injectNow(ro, typeToken())
 
     assertThat(ro.d1).isEqualTo(dep1)
     assertThat(ro.d2).isEqualTo(dep2)

--- a/plugins/mockito-factories/src/main/kotlin/com/episode6/mxo2/plugins/mockito/factories/MockitoAutoFactoryPlugins.kt
+++ b/plugins/mockito-factories/src/main/kotlin/com/episode6/mxo2/plugins/mockito/factories/MockitoAutoFactoryPlugins.kt
@@ -26,7 +26,7 @@ inline fun <reified A : Annotation> MockspressoBuilder.autoFactoriesByAnnotation
  */
 inline fun <reified T : Any?> MockspressoBuilder.autoFactory(qualifier: Annotation? = null): MockspressoBuilder {
   val key = dependencyKey<T>(qualifier)
-  return addDependencyOf(key) { autoFactoryMock(key) }
+  return dependencyOf(key) { autoFactoryMock(key) }
 }
 
 /**

--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -42,7 +42,7 @@ inline fun <reified T : Any?> MockspressoBuilder.defaultMock(
   @Incubating useConstructor: UseConstructor? = null,
   @Incubating outerInstance: Any? = null,
   @Incubating lenient: Boolean = false
-): MockspressoBuilder = addDependencyOf(qualifier) {
+): MockspressoBuilder = dependencyOf(qualifier) {
   Mockito.mock(
     T::class.java,
     withSettings(
@@ -82,7 +82,7 @@ inline fun <reified T : Any?> MockspressoBuilder.defaultMock(
   @Incubating outerInstance: Any? = null,
   @Incubating lenient: Boolean = false,
   noinline stubbing: KStubbing<T>.(T) -> Unit
-): MockspressoBuilder = addDependencyOf(qualifier) {
+): MockspressoBuilder = dependencyOf(qualifier) {
   Mockito.mock(
     T::class.java,
     withSettings(

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -46,7 +46,7 @@ inline fun <reified T : Any?> MockspressoBuilder.defaultMockk(
   vararg moreInterfaces: KClass<*>,
   relaxUnitFun: Boolean = true,
   noinline block: T.() -> Unit = {}
-) = addDependencyOf<T>(qualifier) {
+) = dependencyOf<T>(qualifier) {
   _mockk(
     name = name,
     relaxed = relaxed,


### PR DESCRIPTION
I'm concerned about 
a) inconsistencies in api method names
b) accidental usage of `MockspressoInstance` methods triggering early initialization of graph (and frustrating new users)

In this PR we make 3 renames to address these concerns
1) drop the `add` and `use` prefix  MockspressoBuilder methods for dependencies/realImpls respectively
2) Update `MockspressoBuilder.realImplOf` -> `realImplementationOf` to keep consistency with other builder methods
3) Add `Now` suffix to Mockspresso instance methods and plugin methods to make it more obvious they cause immediate action on the graph.