### PR TITLE
define fakeOf

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -72,6 +72,21 @@ inline fun <reified T : Any?> MockspressoProperties.depOf(
 ): Lazy<T> = depOf(dependencyKey(qualifier), provider)
 
 /**
+ * Register a dependency provided by [provider] that is of type [IMPL] but bound in the mockspresso graph with a
+ * dependencyKey made from type [BIND] and [qualifier]. Returns a [Lazy] with access to that dependency as type [IMPL]
+ *
+ * IMPORTANT: Reading the value from the returned lazy will cause the underlying [MockspressoInstance] to be ensured
+ * if it hasn't been already.
+ */
+@Suppress("UNCHECKED_CAST") inline fun <reified BIND : Any?, IMPL : BIND> MockspressoProperties.fakeOf(
+  qualifier: Annotation? = null,
+  noinline provider: Dependencies.() -> IMPL
+): Lazy<IMPL> {
+  val depLazy = depOf<BIND>(qualifier, provider)
+  return lazy(LazyThreadSafetyMode.NONE) { depLazy.value as IMPL }
+}
+
+/**
  * Find an existing dependency in the underlying mockspresso instance (bound with a dependencyKey of type
  * [T] + [qualifier]) and return a [Lazy] for access to it.
  *
@@ -115,4 +130,4 @@ inline fun <reified T : Any?> MockspressoProperties.realInstance(
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplOf(
   qualifier: Annotation? = null,
   noinline interceptor: (IMPL) -> IMPL = { it }
-): Lazy<IMPL> = realImplOf(dependencyKey<BIND>(qualifier), typeToken(), interceptor)
+): Lazy<IMPL> = realImplOf(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -1,5 +1,6 @@
 package com.episode6.mxo2
 
+import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
 import com.episode6.mxo2.reflect.dependencyKey
@@ -128,12 +129,31 @@ class SimpleIntegrationTest {
     assertThat(someObject.dependency2).isEqualTo(dep2)
   }
 
+  @Test fun testFakeOf() {
+    val mxo = MockspressoBuilder().build()
+
+    val ro: SomeObjectWithIFaceDep by mxo.realInstance()
+    val dep1 by mxo.depOf { SomeDependency1() }
+    val dep2 by mxo.fakeOf<SomeDependency2Interface, SomeDependency2> { SomeDependency2() }
+
+    dep2.doSomething() // method only exists on class
+    assertThat(ro.dependency1).isEqualTo(dep1)
+    assertThat(ro.dependency2).all {
+      isEqualTo(dep2)
+      isInstanceOf(SomeDependency2::class)
+    }
+  }
+
   private class SomeObject(val dependency1: SomeDependency1, val dependency2: SomeDependency2) {
     fun doSomething() {}
   }
 
+  private class SomeObjectWithIFaceDep(val dependency1: SomeDependency1, val dependency2: SomeDependency2Interface)
+
+  interface SomeDependency2Interface
+
   private class SomeDependency1
-  private class SomeDependency2 {
+  private class SomeDependency2 : SomeDependency2Interface {
     fun doSomething() {}
   }
 


### PR DESCRIPTION
While working on getting started docs I realized we're missing a standard way to define a dependency (on MockspressoProperties) where the bind-type differs from the object type && the object type is needed for the test (i.e. `fakes`)

This PR adds a standard extension to the api called `MockspressoPropreties.fakeOf<BIND, IMPL>(): Lazy<IMPL>` which lets us do just that. Example:
```
// bound in mockspresso as Timer
val timer by mxo.fakeOf<Timer, FakeTimer> { FakeTimer() } 

@Test fun useFakeTimer() {
    timer.advanceFakeTime()
}
```