### PR TITLE
Bump pipeline version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     gradleRunner = fileLoader.fromGit(
         'gradle/GradleRunner',
         'git@github.com:episode6/jenkins-pipelines.git',
-        'v0.0.8',
+        'v0.0.9',
         null,
         '')
   }


### PR DESCRIPTION
The old jenkins file isn't aware of `main` branches, so the auto-deploy failed. Fixed in v0.0.9.