### PR TITLE
Remove interceptors and dynamic dependencies from built in extensions

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/Mockspresso.kt
@@ -107,7 +107,7 @@ interface MockspressoBuilder {
    * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
    * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
    */
-  fun <BIND : Any?, IMPL : BIND> realImplementation(
+  fun <BIND : Any?, IMPL : BIND> interceptRealImplementation(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND = { it }
@@ -179,7 +179,7 @@ interface MockspressoProperties {
    * IMPORTANT: Reading the value from the returned lazy will cause the underlying [MockspressoInstance] to be ensured
    * if it hasn't been already.
    */
-  fun <BIND : Any?, IMPL : BIND> realImplementation(
+  fun <BIND : Any?, IMPL : BIND> interceptRealImplementation(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> IMPL = { it }

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -42,7 +42,7 @@ inline fun <reified T : Any?> MockspressoBuilder.realInstance(
   qualifier: Annotation? = null,
   noinline init: (T) -> Unit = { }
 ): MockspressoBuilder = dependencyKey<T>(qualifier).let { key ->
-  realImplementation(key, key.token, interceptor = { it.apply(init) })
+  interceptRealImplementation(key, key.token) { it.apply(init) }
 }
 
 /**
@@ -55,7 +55,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImp
   qualifier: Annotation? = null,
   noinline init: (IMPL) -> Unit = { }
 ): MockspressoBuilder =
-  realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor = { it.apply(init) })
+  interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { it.apply(init) }
 
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
@@ -114,7 +114,7 @@ inline fun <reified T : Any?> MockspressoProperties.realInstance(
   qualifier: Annotation? = null,
   noinline init: (T) -> Unit = { }
 ): Lazy<T> = dependencyKey<T>(qualifier).let { key ->
-  realImplementation(key, key.token, interceptor = { it.apply(init) })
+  interceptRealImplementation(key, key.token) { it.apply(init) }
 }
 
 /**
@@ -130,4 +130,4 @@ inline fun <reified T : Any?> MockspressoProperties.realInstance(
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplementation(
   qualifier: Annotation? = null,
   noinline init: (IMPL) -> Unit = { }
-): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor = { it.apply(init) })
+): Lazy<IMPL> = interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { it.apply(init) }

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -10,7 +10,7 @@ import com.episode6.mxo2.reflect.typeToken
  */
 inline fun <reified T : Any?> MockspressoInstance.createNow(
   qualifier: Annotation? = null
-): T = createNow(dependencyKey(qualifier))
+): T = createNow(dependencyKey<T>(qualifier))
 
 /**
  * Find an existing dependency in this mockspresso instance of type [T] with the provided [qualifier]. If the
@@ -21,7 +21,7 @@ inline fun <reified T : Any?> MockspressoInstance.createNow(
  */
 inline fun <reified T : Any?> MockspressoInstance.findNow(
   qualifier: Annotation? = null
-): T = findNow(dependencyKey(qualifier))
+): T = findNow(dependencyKey<T>(qualifier))
 
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
@@ -30,7 +30,7 @@ inline fun <reified T : Any?> MockspressoInstance.findNow(
 inline fun <reified T : Any?> MockspressoBuilder.dependency(
   qualifier: Annotation? = null,
   noinline provider: () -> T
-): MockspressoBuilder = dependency(dependencyKey(qualifier)) { provider() }
+): MockspressoBuilder = dependency(dependencyKey<T>(qualifier)) { provider() }
 
 /**
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
@@ -69,7 +69,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImp
 inline fun <reified T : Any?> MockspressoProperties.dependency(
   qualifier: Annotation? = null,
   noinline provider: () -> T
-): Lazy<T> = dependency(dependencyKey(qualifier)) { provider() }
+): Lazy<T> = dependency(dependencyKey<T>(qualifier)) { provider() }
 
 /**
  * Register a dependency provided by [provider] that is of type [IMPL] but bound in the mockspresso graph with a
@@ -98,7 +98,7 @@ inline fun <reified T : Any?> MockspressoProperties.dependency(
  */
 inline fun <reified T : Any?> MockspressoProperties.findDependency(
   qualifier: Annotation? = null
-): Lazy<T> = findDependency(dependencyKey(qualifier))
+): Lazy<T> = findDependency(dependencyKey<T>(qualifier))
 
 /**
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -30,7 +30,7 @@ inline fun <reified T : Any?> MockspressoInstance.findNow(
 inline fun <reified T : Any?> MockspressoBuilder.dependency(
   qualifier: Annotation? = null,
   noinline provider: () -> T
-): MockspressoBuilder = dependency(dependencyKey(qualifier), provider = { provider() })
+): MockspressoBuilder = dependency(dependencyKey(qualifier)) { provider() }
 
 /**
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
@@ -69,7 +69,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImp
 inline fun <reified T : Any?> MockspressoProperties.dependency(
   qualifier: Annotation? = null,
   noinline provider: () -> T
-): Lazy<T> = dependency(dependencyKey(qualifier), provider = { provider() })
+): Lazy<T> = dependency(dependencyKey(qualifier)) { provider() }
 
 /**
  * Register a dependency provided by [provider] that is of type [IMPL] but bound in the mockspresso graph with a

--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -1,6 +1,5 @@
 package com.episode6.mxo2
 
-import com.episode6.mxo2.api.Dependencies
 import com.episode6.mxo2.reflect.dependencyKey
 import com.episode6.mxo2.reflect.typeToken
 
@@ -30,32 +29,33 @@ inline fun <reified T : Any?> MockspressoInstance.findNow(
  */
 inline fun <reified T : Any?> MockspressoBuilder.dependency(
   qualifier: Annotation? = null,
-  noinline provider: Dependencies.() -> T
-): MockspressoBuilder = dependency(dependencyKey(qualifier), provider)
+  noinline provider: () -> T
+): MockspressoBuilder = dependency(dependencyKey(qualifier), provider = { provider() })
 
 /**
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
  * type [T] and [qualifier].
  *
- * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
- * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
+ * The supplied [init] lambda will be called when the real object is created.
  */
 inline fun <reified T : Any?> MockspressoBuilder.realInstance(
   qualifier: Annotation? = null,
-  noinline interceptor: (T) -> T = { it }
-): MockspressoBuilder = dependencyKey<T>(qualifier).let { realImplementation(it, it.token, interceptor) }
+  noinline init: (T) -> Unit = { }
+): MockspressoBuilder = dependencyKey<T>(qualifier).let { key ->
+  realImplementation(key, key.token, interceptor = { it.apply(init) })
+}
 
 /**
  * Register a request to create a real object of type [IMPL] bound in the mockspresso graph with a dependencyKey made
  * from type [BIND] and [qualifier].
  *
- * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
- * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
+ * The supplied [init] lambda will be called when the real object is created.
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImplementation(
   qualifier: Annotation? = null,
-  noinline interceptor: (IMPL) -> BIND = { it }
-): MockspressoBuilder = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
+  noinline init: (IMPL) -> Unit = { }
+): MockspressoBuilder =
+  realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor = { it.apply(init) })
 
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
@@ -68,8 +68,8 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImp
  */
 inline fun <reified T : Any?> MockspressoProperties.dependency(
   qualifier: Annotation? = null,
-  noinline provider: Dependencies.() -> T
-): Lazy<T> = dependency(dependencyKey(qualifier), provider)
+  noinline provider: () -> T
+): Lazy<T> = dependency(dependencyKey(qualifier), provider = { provider() })
 
 /**
  * Register a dependency provided by [provider] that is of type [IMPL] but bound in the mockspresso graph with a
@@ -80,7 +80,7 @@ inline fun <reified T : Any?> MockspressoProperties.dependency(
  */
 @Suppress("UNCHECKED_CAST") inline fun <reified BIND : Any?, IMPL : BIND> MockspressoProperties.fake(
   qualifier: Annotation? = null,
-  noinline provider: Dependencies.() -> IMPL
+  noinline provider: () -> IMPL
 ): Lazy<IMPL> {
   val depLazy = dependency<BIND>(qualifier, provider)
   return lazy(LazyThreadSafetyMode.NONE) { depLazy.value as IMPL }
@@ -104,8 +104,7 @@ inline fun <reified T : Any?> MockspressoProperties.findDependency(
  * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
  * type [T] and [qualifier].
  *
- * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
- * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
+ * The supplied [init] lambda will be called when the real object is created.
  *
  * Returns a [Lazy] of the resulting real object
  * IMPORTANT: Reading the value from the returned lazy will cause the underlying [MockspressoInstance] to be ensured
@@ -113,15 +112,16 @@ inline fun <reified T : Any?> MockspressoProperties.findDependency(
  */
 inline fun <reified T : Any?> MockspressoProperties.realInstance(
   qualifier: Annotation? = null,
-  noinline interceptor: (T) -> T = { it }
-): Lazy<T> = dependencyKey<T>(qualifier).let { realImplementation(it, it.token, interceptor) }
+  noinline init: (T) -> Unit = { }
+): Lazy<T> = dependencyKey<T>(qualifier).let { key ->
+  realImplementation(key, key.token, interceptor = { it.apply(init) })
+}
 
 /**
  * Register a request to create a real object of type [IMPL] bound in the mockspresso graph with a dependencyKey made
  * from type [BIND] and [qualifier].
  *
- * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
- * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
+ * The supplied [init] lambda will be called when the real object is created.
  *
  * Returns a [Lazy] of the resulting real object
  * IMPORTANT: Reading the value from the returned lazy will cause the underlying [MockspressoInstance] to be ensured
@@ -129,5 +129,5 @@ inline fun <reified T : Any?> MockspressoProperties.realInstance(
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplementation(
   qualifier: Annotation? = null,
-  noinline interceptor: (IMPL) -> IMPL = { it }
-): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor)
+  noinline init: (IMPL) -> Unit = { }
+): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>(), interceptor = { it.apply(init) })

--- a/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mxo2/internal/MockspressoContainers.kt
@@ -39,7 +39,7 @@ internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : 
   override fun <T> dependency(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder =
     apply { builder.dependencyOf(key, provider) }
 
-  override fun <BIND : Any?, IMPL : BIND> realImplementation(
+  override fun <BIND : Any?, IMPL : BIND> interceptRealImplementation(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> BIND
@@ -78,7 +78,7 @@ private class MockspressoPropertiesContainer(
   }
 
   @Suppress("UNCHECKED_CAST")
-  override fun <BIND, IMPL : BIND> realImplementation(
+  override fun <BIND, IMPL : BIND> interceptRealImplementation(
     key: DependencyKey<BIND>,
     implementationToken: TypeToken<IMPL>,
     interceptor: (IMPL) -> IMPL

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/CircularDependencyTest.kt
@@ -38,7 +38,7 @@ class CircularDependencyTest {
   @Test fun testCircularDependency_stillFailsOnDynamicDependency() {
     val mxo = MockspressoBuilder()
       .realInstance<A?>()
-      .dependency<B?> { B(get(dependencyKey())) }
+      .dependency<B?>(dependencyKey()) { B(get(dependencyKey())) }
       .build()
 
     val c by mxo.realImplementation<C?, C>()

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -98,7 +98,7 @@ class SimpleIntegrationTest {
       .dependency { SomeDependency1() }
       .build()
 
-    val dep2: SomeDependency2 by mxo.realImplementation(dependencyKey(), typeToken()) { spyk(it) }
+    val dep2: SomeDependency2 by mxo.interceptRealImplementation(dependencyKey(), typeToken()) { spyk(it) }
     val objUnderTest: SomeObject by mxo.realInstance()
 
     assertThat(dep2).isEqualTo(objUnderTest.dependency2)

--- a/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mxo2/SimpleIntegrationTest.kt
@@ -4,6 +4,7 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
 import com.episode6.mxo2.reflect.dependencyKey
+import com.episode6.mxo2.reflect.typeToken
 import io.mockk.spyk
 import io.mockk.verify
 import kotlin.test.Test
@@ -97,7 +98,7 @@ class SimpleIntegrationTest {
       .dependency { SomeDependency1() }
       .build()
 
-    val dep2: SomeDependency2 by mxo.realInstance { spyk(it) }
+    val dep2: SomeDependency2 by mxo.realImplementation(dependencyKey(), typeToken()) { spyk(it) }
     val objUnderTest: SomeObject by mxo.realInstance()
 
     assertThat(dep2).isEqualTo(objUnderTest.dependency2)
@@ -107,7 +108,7 @@ class SimpleIntegrationTest {
 
   @Test fun testDynamicDependency() {
     val mxo = MockspressoBuilder()
-      .dependency { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+      .dependency(dependencyKey()) { SomeObject(get(dependencyKey()), get(dependencyKey())) }
       .build()
 
     val dep1 by mxo.dependency { SomeDependency1() }
@@ -121,7 +122,7 @@ class SimpleIntegrationTest {
   @Test fun testDynamicDependencyInProp() {
     val mxo = MockspressoBuilder().build()
 
-    val someObject by mxo.dependency { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+    val someObject by mxo.dependency(dependencyKey()) { SomeObject(get(dependencyKey()), get(dependencyKey())) }
     val dep1 by mxo.dependency { SomeDependency1() }
     val dep2 by mxo.dependency { SomeDependency2() }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Remove mention of `Dependencies` and real object interceptors from the standard extension functions in the api. The
   interceptors specifically are a bit too powerful and easy to mis-use / misunderstand. Replace the interceptors with
   simple init blocks. Both the interceptors and dynamic `Dependencies` are available in the interface methods.
+- Renamed interface method `realImplementation` to `interceptRealImplementation` to differentiate it from the extension
+  functions (which retain their old names), since the intentions of the two lambdas are totally different.
 
 ### v2.0.0-alpha01 - Released 2/21/2022
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### v2.0.0-alpha02-SNAPSHOT - Unreleased
 
+- Remove mention of `Dependencies` and real object interceptors from the standard extension functions in the api. The
+  interceptors specifically are a bit too powerful and easy to mis-use / misunderstand. Replace the interceptors with
+  simple init blocks. Both the interceptors and dynamic `Dependencies` are available in the interface methods.
 
 ### v2.0.0-alpha01 - Released 2/21/2022
 

--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -188,7 +188,7 @@ inline fun <reified T : Any?> MockspressoProperties.mock(
  * graph and can be used by other real objects (and then verified in test code).
  */
 inline fun <reified T : Any?> MockspressoProperties.spy(qualifier: Annotation? = null): Lazy<T> =
-  realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it) }
+  interceptRealImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it) }
 
 /**
  * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be part of the mockspresso
@@ -198,7 +198,7 @@ inline fun <reified T : Any?> MockspressoProperties.spy(qualifier: Annotation? =
 inline fun <reified T : Any?> MockspressoProperties.spy(
   qualifier: Annotation? = null,
   noinline stubbing: KStubbing<T>.(T) -> Unit
-): Lazy<T> = realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it, stubbing) }
+): Lazy<T> = interceptRealImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it, stubbing) }
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
@@ -206,7 +206,7 @@ inline fun <reified T : Any?> MockspressoProperties.spy(
  * (and then verified in test code).
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
-  realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it) }
+  interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it) }
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
@@ -217,4 +217,4 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyI
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(
   qualifier: Annotation? = null,
   noinline stubbing: KStubbing<IMPL>.(IMPL) -> Unit
-): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it, stubbing) }
+): Lazy<IMPL> = interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it, stubbing) }

--- a/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mxo2/plugins/mockito/MockitoPlugins.kt
@@ -1,9 +1,13 @@
 package com.episode6.mxo2.plugins.mockito
 
-import com.episode6.mxo2.*
+import com.episode6.mxo2.MockspressoBuilder
+import com.episode6.mxo2.MockspressoProperties
 import com.episode6.mxo2.api.FallbackObjectMaker
+import com.episode6.mxo2.dependency
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.asJClass
+import com.episode6.mxo2.reflect.dependencyKey
+import com.episode6.mxo2.reflect.typeToken
 import org.mockito.Incubating
 import org.mockito.Mockito
 import org.mockito.kotlin.KStubbing
@@ -184,7 +188,7 @@ inline fun <reified T : Any?> MockspressoProperties.mock(
  * graph and can be used by other real objects (and then verified in test code).
  */
 inline fun <reified T : Any?> MockspressoProperties.spy(qualifier: Annotation? = null): Lazy<T> =
-  realInstance(qualifier) { spy(it) }
+  realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it) }
 
 /**
  * Create a real object of [T] using mockspresso then wrap it in a mockito [spy]. This spy will be part of the mockspresso
@@ -194,7 +198,7 @@ inline fun <reified T : Any?> MockspressoProperties.spy(qualifier: Annotation? =
 inline fun <reified T : Any?> MockspressoProperties.spy(
   qualifier: Annotation? = null,
   noinline stubbing: KStubbing<T>.(T) -> Unit
-): Lazy<T> = realInstance(qualifier) { spy(it, stubbing) }
+): Lazy<T> = realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) { spy(it, stubbing) }
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
@@ -202,7 +206,7 @@ inline fun <reified T : Any?> MockspressoProperties.spy(
  * (and then verified in test code).
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(qualifier: Annotation? = null): Lazy<IMPL> =
-  realImplementation<BIND, IMPL>(qualifier) { spy(it) }
+  realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it) }
 
 /**
  * Create a real object of type [IMPL] using mockspresso then wrap it in a mockito [spy] (the object will be bound
@@ -213,4 +217,4 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyI
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyImplOf(
   qualifier: Annotation? = null,
   noinline stubbing: KStubbing<IMPL>.(IMPL) -> Unit
-): Lazy<IMPL> = realImplementation<BIND, IMPL>(qualifier) { spy(it, stubbing) }
+): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { spy(it, stubbing) }

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -89,7 +89,7 @@ inline fun <reified T : Any?> MockspressoProperties.spyk(
   vararg moreInterfaces: KClass<*>,
   recordPrivateCalls: Boolean = false,
   noinline block: T.() -> Unit = {}
-): Lazy<T> = realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) {
+): Lazy<T> = interceptRealImplementation(dependencyKey<T>(qualifier), typeToken<T>()) {
   _spyk(
     objToCopy = it!!,
     name = name,
@@ -110,7 +110,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyk
   vararg moreInterfaces: KClass<*>,
   recordPrivateCalls: Boolean = false,
   noinline block: IMPL.() -> Unit = {}
-): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) {
+): Lazy<IMPL> = interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) {
   _spyk(
     objToCopy = it!!,
     name = name,

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mxo2/plugins/mockk/MockkPlugins.kt
@@ -6,6 +6,8 @@ import com.episode6.mxo2.*
 import com.episode6.mxo2.api.FallbackObjectMaker
 import com.episode6.mxo2.reflect.DependencyKey
 import com.episode6.mxo2.reflect.asKClass
+import com.episode6.mxo2.reflect.dependencyKey
+import com.episode6.mxo2.reflect.typeToken
 import io.mockk.MockK
 import io.mockk.MockKGateway
 import kotlin.reflect.KClass
@@ -87,7 +89,7 @@ inline fun <reified T : Any?> MockspressoProperties.spyk(
   vararg moreInterfaces: KClass<*>,
   recordPrivateCalls: Boolean = false,
   noinline block: T.() -> Unit = {}
-): Lazy<T> = realInstance<T>(qualifier) {
+): Lazy<T> = realImplementation(dependencyKey<T>(qualifier), typeToken<T>()) {
   _spyk(
     objToCopy = it!!,
     name = name,
@@ -108,7 +110,7 @@ inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.spyk
   vararg moreInterfaces: KClass<*>,
   recordPrivateCalls: Boolean = false,
   noinline block: IMPL.() -> Unit = {}
-): Lazy<IMPL> = realImplementation<BIND, IMPL>(qualifier) {
+): Lazy<IMPL> = realImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) {
   _spyk(
     objToCopy = it!!,
     name = name,


### PR DESCRIPTION
Remove mention of `Dependencies` and real object interceptors from the standard extension functions in the api. The  interceptors specifically are a bit too powerful and easy to mis-use / misunderstand. Replace the interceptors with simple init blocks. 

Both the interceptors and dynamic `Dependencies` are available in the interface methods and will still be available for plugins to leverage. 

Came to this decision while some of the first demo implementations. The real object I was creating required an extra init, and I realized that's a far more common scenario IRL than needing to wrap the entire object (which should probably be contained to spy plugins).