### PR TITLE
Fix realInstance/Impl lambdas to use receiver

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mxo2/MockspressoExt.kt
@@ -40,7 +40,7 @@ inline fun <reified T : Any?> MockspressoBuilder.dependency(
  */
 inline fun <reified T : Any?> MockspressoBuilder.realInstance(
   qualifier: Annotation? = null,
-  noinline init: (T) -> Unit = { }
+  noinline init: T.() -> Unit = { }
 ): MockspressoBuilder = dependencyKey<T>(qualifier).let { key ->
   interceptRealImplementation(key, key.token) { it.apply(init) }
 }
@@ -53,7 +53,7 @@ inline fun <reified T : Any?> MockspressoBuilder.realInstance(
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImplementation(
   qualifier: Annotation? = null,
-  noinline init: (IMPL) -> Unit = { }
+  noinline init: IMPL.() -> Unit = { }
 ): MockspressoBuilder =
   interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { it.apply(init) }
 
@@ -112,7 +112,7 @@ inline fun <reified T : Any?> MockspressoProperties.findDependency(
  */
 inline fun <reified T : Any?> MockspressoProperties.realInstance(
   qualifier: Annotation? = null,
-  noinline init: (T) -> Unit = { }
+  noinline init: T.() -> Unit = { }
 ): Lazy<T> = dependencyKey<T>(qualifier).let { key ->
   interceptRealImplementation(key, key.token) { it.apply(init) }
 }
@@ -129,5 +129,5 @@ inline fun <reified T : Any?> MockspressoProperties.realInstance(
  */
 inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoProperties.realImplementation(
   qualifier: Annotation? = null,
-  noinline init: (IMPL) -> Unit = { }
+  noinline init: IMPL.() -> Unit = { }
 ): Lazy<IMPL> = interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { it.apply(init) }


### PR DESCRIPTION
This was an oversight in https://github.com/episode6/mockspresso2/pull/55 (which I probably should have waited to merge until the morning).

The idea here is than in the more common use-cases for the `realInstance {}` method, the lamba would be most useful as an `apply{}` block to allow for an additional init step (rather than it's original intention to act as an intercept for `spy` support - which would be limited to other plugins and could use the more verbose interface method).

However, when making the change I forgot to tweak the lambda signature, so irl the usage looks like `realInstance { it.onCreate() }`. This PR corrects that usage to the more natural `realInstance { onCreate() }`.