### PR TITLE
Transition to trunk base development model

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     gradleRunner = fileLoader.fromGit(
         'gradle/GradleRunner',
         'git@github.com:episode6/jenkins-pipelines.git',
-        'v0.0.9',
+        'v0.0.10',
         null,
         '')
   }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # mockspresso2
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.episode6.mockspresso2/core.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.mockspresso2%22)
+
 Kotlin multi-platform re-write of mockspresso
 
-[Mockspresso2 docs](docs/README.md)
+[Mockspresso2 docs](https://episode6.github.io/mockspresso2/)

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,35 +1,47 @@
 ## Mockspresso2 Release Checklist
 
-**Start Release**
+(we should be able to automate most of this eventually)
 
-1. Ensure `develop` branch is green
-2. `git flow release start v<version>`
-3. Update version in `build.gradle.kts`
-4. Update version in `docs/CHANGELOG.md`
-5. Update version in `docs/PROJECT_SETUP.md`
-7. Commit changes with message `[VERSION] Release v<version>`
-8. **DO NOT PUSH**
+### Cut new Release Branch
 
-**Bump Snapshot Version**
+1. Ensure main branch is green
+2. `git checkout -b release/v<VERSION>`
+3. Push/track empty branch
 
-1. Checkout `develp` branch
-2. Update SNAPSHOT version in `build.gradle`
-3. Update SNAPSHOT version in `docs/CHANGELOG.md`
-4. Update SNAPSHOT version in `docs/PROJECT_SETUP.md`
-5. Commit changes with message `[VERSION] Snapshot v<version>`
-6. **Push both branches**
+### Version bump PRs
 
-**Sync Docs**
+- Create 2 PRs to bump version
+    - `[VERSION] Snapshot v<version>` points at `main`
+    - `[VERSION] Release v<version>` points at new release branch
+    - Update version in files:
+        - `build.gradle.kts`
+        - `docs/CHANGELOG.md`
+        - `docs/PROJECT_SETUP.md`
 
-1. Checkout release branch
+### Harden Release Branch
+
+- Fix any bugs on the `main` branch first then cherry-pick (via PR) into release branch
+
+### Release
+
+1. Wait for green builds on release branch
+2. Fetch tags: `git fetch origin --tags`
+3. Create new release tag: `git tag -a v<VERSION>`
+4. Push tags: `git push --tags`
+5. Build tag on jenkins and deploy result on sonatype
+
+### Sync Docs PR
+
+1. **IMPORTANT** POINT GITHUB PAGES TO NEW BRANCH NOW
+    - pages will not re-publish until we push to the branch again
 2. Run `./gradlew syncDocs`
-3. Commit changes with message `[DOCS] Sync v<version>`
-4. Push branch
+3. If there are no changes in docs, make a non-visible change to a README
+    - we need a commit to trigger github pages generation
+4. Point PR to new release branch: `[DOCS] Sync v<version>`
 
-**Release**
+### Hotfixes
 
-1. Wait for green builds
-2. `git flow release finish` (tag with `v<version>`)
-3. Resolve merge conflicts on develop
-   1. replace repo in `docs/PROJECT_SETUP.md` - `maven { url "https://oss.sonatype.org/content/repositories/snapshots" }`
-4. Push branches
+- We do not cut new release branches for hotfixes, instead we append to the effected release branch and add a new
+  release tag
+- All fixes (including hotfixes) should be applied to the `main` branch first whenever possible and cherry-picked onto
+  the appropriate release-branch for a hotfix.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
   group = "com.episode6.mockspresso2"
-  version = "2.0.0-alpha03-SNAPSHOT"
+  version = "2.0.0-alpha04-SNAPSHOT"
 }
 
 tasks.register<Delete>("clean") {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+### v2.0.0-alpha04-SNAPSHOT - Unreleased
+
+
 ### v2.0.0-alpha03-SNAPSHOT - Unreleased
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v2.0.0-alpha04-SNAPSHOT - Unreleased
 
+- Transition from git-flow to trunk based development / releases
 
 ### v2.0.0-alpha03 - Released 2/26/2022
 

--- a/docs/PROJECT_SETUP.md
+++ b/docs/PROJECT_SETUP.md
@@ -3,7 +3,7 @@ Ideally, mockspresso should only be exposed to tests via a dedicated gradle modu
 
 ### Gradle setup
 ```groovy
-def mxoVersion = '2.0.0-alpha03-SNAPSHOT'
+def mxoVersion = '2.0.0-alpha04-SNAPSHOT'
 
 repositories { maven { url "https://oss.sonatype.org/content/repositories/snapshots" } }
 dependencies {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ## Get Up & Running
- - See the [Project Setup](PROJECT_SETUP.md) doc for current version & setup instructions.
- - See the [Getting Started](GETTING_STARTED.md) doc to start writing tests.
+ - Current Version: [![Maven Central](https://img.shields.io/maven-central/v/com.episode6.mockspresso2/core.svg?style=flat-square)](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.episode6.mockspresso2%22)
+ - See [Project Setup](PROJECT_SETUP.md) for setup instructions.
+ - See [Getting Started](GETTING_STARTED.md) to start writing tests.
 
 ## What & Why?
 Mockspresso2 acts like a smart, single-use DI graph for kotlin unit and integration tests where any missing dependencies can be mocked automatically. The goal is to reduce the friction, boilerplate, brittleness and barrier-to-entry when writing unit-tests, enabling engineers to focus on what matters.


### PR DESCRIPTION
This PR merges the `develop` branch into the `main` without creating a git-flow release and begins our official transition off of git-flow and onto to trunk-based development.

- After this PR, `main` will be the SNAPSHOT branch and `develop` will be deleted
- We've already pointed our gh pages to a temp branch off of `main` (before this merge) to avoid it being updated with the SNAPSHOT readme
- After this PR, merge-commits will again be banned in favor of squash commits