### PR TITLE
Update jenkins-pipeline to v0.0.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     gradleRunner = fileLoader.fromGit(
         'gradle/GradleRunner',
         'git@github.com:episode6/jenkins-pipelines.git',
-        'feature/only-deploy-tag-jobs',
+        'v0.0.11',
         null,
         '')
   }
@@ -23,4 +23,3 @@ node {
 
   gradleRunner.deploy()
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
     gradleRunner = fileLoader.fromGit(
         'gradle/GradleRunner',
         'git@github.com:episode6/jenkins-pipelines.git',
-        'v0.0.10',
+        'feature/only-deploy-tag-jobs',
         null,
         '')
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,4 +23,3 @@ node {
 
   gradleRunner.deploy()
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,3 +23,4 @@ node {
 
   gradleRunner.deploy()
 }
+

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -24,7 +24,7 @@
 
 ### Release
 
-1. Create new release with new tag on github
+1. Create new release with new tag on github (pointing to release branch)
 2. Build new tag on jenkins (will deploy)
 3. Release/Close new repo on [sonatype](https://oss.sonatype.org/)
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -24,19 +24,15 @@
 
 ### Release
 
-1. Wait for green builds on release branch
-2. Fetch tags: `git fetch origin --tags`
-3. Create new release tag: `git tag -a v<VERSION>`
-4. Push tags: `git push --tags`
-5. Build tag on jenkins and deploy result on sonatype
+1. Create new release with new tag on github
+2. Build new tag on jenkins (will deploy)
+3. Release/Close new repo on [sonatype](https://oss.sonatype.org/)
 
 ### Sync Docs PR
 
-1. **IMPORTANT** POINT GITHUB PAGES TO NEW BRANCH NOW
-    - pages will not re-publish until we push to the branch again
+1. Point github pages to the new release branch
 2. Run `./gradlew syncDocs`
-3. If there are no changes in docs, make a non-visible change to a README
-    - we need a commit to trigger github pages generation
+3. If there are no changes in docs, you can skip this
 4. Point PR to new release branch: `[DOCS] Sync v<version>`
 
 ### Hotfixes


### PR DESCRIPTION
This should stop any auto-deploys firing on jenkins branch jobs, and reserve that for tag jobs