### PR TITLE
Fix publish workflow (github actions)

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Sync Docs
         run: ./gradlew syncDocs
       - name: Deploy root docs to website
-        if: ${{ github.ref_type == 'tag' && github.repository == 'episode6/redux-store-flow' }}
+        if: ${{ github.ref_type == 'tag' && github.repository == 'episode6/mockspresso2' }}
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,7 +42,7 @@ jobs:
           TARGET_FOLDER: /
           CLEAN: false
       - name: Deploy dokka to website
-        if: ${{ github.repository == 'episode6/redux-store-flow' }}
+        if: ${{ github.repository == 'episode6/mockspresso2' }}
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
docs weren't getting published because of a failed if check on the repo name