### PR TITLE
Remove buildSrc dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-  id("org.jetbrains.dokka")
+  kotlin("multiplatform") version (libs.versions.kotlin.core.get()) apply (false)
+  id("org.jetbrains.dokka") version (libs.versions.dokka.core.get())
 }
 
 allprojects {
@@ -18,17 +19,17 @@ tasks.wrapper {
   distributionType = Wrapper.DistributionType.ALL
 }
 
-val dokkaDir = "$buildDir/dokka/html"
-val siteDir = "$buildDir/site"
+val dokkaDir = "${rootProject.buildDir}/dokka/html"
+val siteDir = "${rootProject.buildDir}/site"
 
 tasks.create<Delete>("clearDokkaDir") {
   delete(dokkaDir)
-  doLast { file("$rootDir/$dokkaDir").mkdirs() }
+  doLast { file(dokkaDir).mkdirs() }
 }
 
 tasks.dokkaHtmlMultiModule {
   dependsOn("clearDokkaDir")
-  outputDirectory.set(file("$rootDir/$dokkaDir"))
+  outputDirectory.set(file(dokkaDir))
 }
 
 tasks.create<Copy>("copyReadmes") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,10 +2,6 @@ plugins {
   `java-gradle-plugin`
 }
 
-dependencies {
-  runtimeOnly(libs.bundles.gradle.plugins)
-}
-
 gradlePlugin {
   plugins {
     create("ConfigureJvmPlugin") {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,9 +1,0 @@
-enableFeaturePreview("VERSION_CATALOGS")
-dependencyResolutionManagement {
-  repositories {
-    mavenCentral()
-  }
-  versionCatalogs {
-    create("libs") { from(files("../libs.versions.toml")) }
-  }
-}


### PR DESCRIPTION
In order to keep all our versions in a version catalog, we used to apply our plugin dependencies as runtime deps on our `buildSrc` project. However we no longer need to do that and can instead just get our versions from inside the plugins block. This should result in better optimized builds.

Piggyback: some no-op syntax changes to our root build.gradle.kts