### PR TITLE
Bump changelog - pretend beta01 didn't exist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v2.0.0-SNAPSHOT - Unreleased
 
-### v2.0.0-beta01 - Released 10/24/2022
+### v2.0.0-rc1 - Released 10/24/2022
 
 - No code changes
 


### PR DESCRIPTION
We screwed up shipping the docs for beta01 so we're going to pretend it didn't exist and goto rc1