### PR TITLE
Add `fun MockspressoProperties.addDynamicObjectMaker()`

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
@@ -93,7 +93,7 @@ interface MockspressoBuilder {
    * Adds a [DynamicObjectMaker] to this [MockspressoInstance]. A [DynamicObjectMaker] gets a chance to supply any
    * un-cached/undefined dependency before the request goes to the [FallbackObjectMaker]. This enables mockspresso
    * plugins supply dependencies based on properties other than concrete types (i.e. generic types, class annotations,
-   * etc.).
+   * etc.). It also allows for "default" instances for bindings, which can be overridden by an explicit dependency.
    */
   fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder // formerly special object makers
 
@@ -149,6 +149,14 @@ interface MockspressoProperties {
    * is not supported by default but can be configured using plugins).
    */
   fun onTeardown(cmd: () -> Unit)
+
+  /**
+   * Adds a [DynamicObjectMaker] to this [MockspressoInstance]. A [DynamicObjectMaker] gets a chance to supply any
+   * un-cached/undefined dependency before the request goes to the [FallbackObjectMaker]. This enables mockspresso
+   * plugins supply dependencies based on properties other than concrete types (i.e. generic types, class annotations,
+   * etc.). It also allows for "default" instances for bindings, which can be overridden by an explicit dependency.
+   */
+  fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker)
 
   /**
    * Register a dependency provided by [provider], bound in the mockspresso graph with [key] and return a [Lazy]

--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
@@ -72,6 +72,10 @@ private class MockspressoPropertiesContainer(
     builder.onTearDown(cmd)
   }
 
+  override fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker) {
+    builder.addDynamicMaker(dynamicMaker)
+  }
+
   override fun <T> dependency(key: DependencyKey<T>, provider: Dependencies.() -> T): Lazy<T> {
     builder.dependencyOf(key, provider)
     return findDependency(key)

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
@@ -7,6 +7,13 @@ import kotlin.test.Test
 
 class DynamicObjectMakerTest {
 
+  private fun defaultTestInterfaceMaker() = DynamicObjectMaker { key, _ ->
+    when (key.token.type.classifier) {
+      TestInterface::class -> DynamicObjectMaker.Answer.Yes(TestObject("default"))
+      else                 -> DynamicObjectMaker.Answer.No
+    }
+  }
+
   @Test fun testUsageInBuilder() {
     val mxo = MockspressoBuilder()
       .addDynamicObjectMaker(defaultTestInterfaceMaker())
@@ -44,13 +51,6 @@ class DynamicObjectMakerTest {
 
     assertThat(parent.testObject.id).isEqualTo("override")
     assertThat(parent.testObject).isEqualTo(override)
-  }
-
-  private fun defaultTestInterfaceMaker() = DynamicObjectMaker { key, _ ->
-    when (key.token.type.classifier) {
-      TestInterface::class -> DynamicObjectMaker.Answer.Yes(TestObject("default"))
-      else                 -> DynamicObjectMaker.Answer.No
-    }
   }
 
   private interface TestInterface {

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
@@ -17,12 +17,33 @@ class DynamicObjectMakerTest {
     assertThat(parent.testObject.id).isEqualTo("default")
   }
 
+  @Test fun testUsageInBuilder_override() {
+    val mxo = MockspressoBuilder()
+      .addDynamicObjectMaker(defaultTestInterfaceMaker())
+      .dependency<TestInterface> { TestObject("override") }
+      .build()
+
+    val parent: TestParent by mxo.realImplementation()
+
+    assertThat(parent.testObject.id).isEqualTo("override")
+  }
+
   @Test fun testUsageInProperties() {
     val mxo = MockspressoBuilder().build()
     mxo.addDynamicObjectMaker(defaultTestInterfaceMaker())
     val parent: TestParent by mxo.realImplementation()
 
     assertThat(parent.testObject.id).isEqualTo("default")
+  }
+
+  @Test fun testUsageInProperties_override() {
+    val mxo = MockspressoBuilder().build()
+    mxo.addDynamicObjectMaker(defaultTestInterfaceMaker())
+    val parent: TestParent by mxo.realImplementation()
+    val override by mxo.dependency<TestInterface> { TestObject("override") }
+
+    assertThat(parent.testObject.id).isEqualTo("override")
+    assertThat(parent.testObject).isEqualTo(override)
   }
 
   private fun defaultTestInterfaceMaker() = DynamicObjectMaker { key, _ ->

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
@@ -1,0 +1,42 @@
+package com.episode6.mockspresso2
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.episode6.mockspresso2.api.DynamicObjectMaker
+import kotlin.test.Test
+
+class DynamicObjectMakerTest {
+
+  @Test fun testUsageInBuilder() {
+    val mxo = MockspressoBuilder()
+      .addDynamicObjectMaker(defaultTestInterfaceMaker())
+      .build()
+
+    val parent: TestParent by mxo.realImplementation()
+
+    assertThat(parent.testObject.id).isEqualTo("default")
+  }
+
+  @Test fun testUsageInProperties() {
+    val mxo = MockspressoBuilder().build()
+    mxo.addDynamicObjectMaker(defaultTestInterfaceMaker())
+    val parent: TestParent by mxo.realImplementation()
+
+    assertThat(parent.testObject.id).isEqualTo("default")
+  }
+
+  private fun defaultTestInterfaceMaker() = DynamicObjectMaker { key, _ ->
+    when (key.token.type.classifier) {
+      TestInterface::class -> DynamicObjectMaker.Answer.Yes(TestObject("default"))
+      else                 -> DynamicObjectMaker.Answer.No
+    }
+  }
+
+  private interface TestInterface {
+    val id: String?
+  }
+
+  private class TestObject(override val id: String?) : TestInterface
+
+  private class TestParent(val testObject: TestInterface)
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### v2.0.0-SNAPSHOT - Unreleased
 
+- Added `fun MockspressoProperties.addDynamicObjectMaker`
+
 ### v2.0.0-rc1 - Released 10/24/2022
 
 - No code changes


### PR DESCRIPTION
Discovered a valid use case for adding dynamic object makers via MockspressoProperties, so we're adding support for it.

UseCase: When integrating with an existing JUnit rule or extension, it can make sense to use DynamicObjectMakers to define default versions of dependencies (which can be overridden by an explicit mapping of said dependency).
