### PR TITLE
Automatically post changelog to release

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -50,4 +50,10 @@ jobs:
           FOLDER: build/dokka/html
           TARGET_FOLDER: /docs/${{ github.ref_name }}/
           CLEAN: true
+      - name: Publish Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        if: ${{ github.ref_type == 'tag' && github.repository == 'episode6/mockspresso2' }}
+        with:
+          body_path: VERSION_CHANGELOG.md
+          append_body: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 local.properties
 build/
 out/
+VERSION_CHANGELOG.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,3 +15,16 @@ tasks.wrapper {
   gradleVersion = libs.versions.gradle.core.get()
   distributionType = Wrapper.DistributionType.ALL
 }
+
+val chopChangelog = tasks.create("chopChangelog") {
+  val allContent = file("$rootDir/docs/CHANGELOG.md").readLines()
+  val firstHeaderIndex = allContent.indexOfFirst { it.startsWith("###") }
+  val topContent = allContent.drop(firstHeaderIndex+1)
+  val nextHeaderIndex = topContent.indexOfFirst { it.startsWith("###") }
+  val versionContent = listOf("### Changelog") + topContent.subList(0, nextHeaderIndex)
+  file("$rootDir/VERSION_CHANGELOG.md").writeText(versionContent.joinToString(separator = "\n"))
+}
+
+tasks.getByName("syncDocs") {
+  dependsOn(chopChangelog)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,12 +17,12 @@ tasks.wrapper {
 }
 
 val chopChangelog = tasks.create("chopChangelog") {
-  val allContent = file("$rootDir/docs/CHANGELOG.md").readLines()
-  val firstHeaderIndex = allContent.indexOfFirst { it.startsWith("###") }
-  val topContent = allContent.drop(firstHeaderIndex+1)
-  val nextHeaderIndex = topContent.indexOfFirst { it.startsWith("###") }
-  val versionContent = listOf("### Changelog") + topContent.subList(0, nextHeaderIndex)
-  file("$rootDir/VERSION_CHANGELOG.md").writeText(versionContent.joinToString(separator = "\n"))
+  val versionContent = file("$rootDir/docs/CHANGELOG.md").readLines()
+    .let { list -> list.drop(list.indexOfFirst { it.startsWith("###") }+1) }
+    .let { list -> list.subList(0, list.indexOfFirst { it.startsWith("###") }) }
+    .let { listOf("### Changelog") + it }
+    .joinToString(separator = "\n")
+  file("$rootDir/VERSION_CHANGELOG.md").writeText(versionContent)
 }
 
 tasks.getByName("syncDocs") {


### PR DESCRIPTION
 - Add a gradle task to cut out just the latest notes from the changelog
 - Have task run as part of syncDocs
 - Append version_changelog to release notes. 