### PR TITLE
Warm the whole dependency cache during ensureInit

### DIFF
--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MxoInstance.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MxoInstance.kt
@@ -36,6 +36,8 @@ internal class MxoInstance(
       }
     }
 
+    dependencies.warmCache()
+    
     // fire setup callbacks
     val container = MockspressoInstanceContainer(this)
     setupCallbacks.forEach { it.invoke(container) }

--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/util/DependencyCache.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/util/DependencyCache.kt
@@ -17,6 +17,10 @@ internal class DependencyCache {
     it.validator.absorb(validator)
     it.lazy.value as T
   }
+
+  fun warmCache() {
+    map.values.forEach { it.lazy.value }
+  }
 }
 
 private class CacheEntry(val lazy: Lazy<*>, val validator: DependencyValidator)

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/EnsureInitWithNoInstanceTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/EnsureInitWithNoInstanceTest.kt
@@ -1,0 +1,32 @@
+package com.episode6.mockspresso2
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class EnsureInitWithNoInstanceTest {
+  private val mxo = MockspressoBuilder().build()
+
+  private var depCreated = false
+  private val dep by mxo.dependency {
+    depCreated = true
+    Unit
+  }
+
+  @Test fun testNoInitNoTouch() {
+    assertThat(depCreated).isFalse()
+  }
+
+  @Test fun testEnsureInit() {
+   mxo.ensureInit()
+
+   assertThat(depCreated).isTrue()
+  }
+
+  @Test fun testTouch() {
+    dep
+
+    assertThat(depCreated).isTrue()
+  }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v2.0.1-SNAPSHOT - Unreleased
 
 - Update junit4 rule to ensure teardown is called even when the test fails/throws
-- All dependencies are now created when the mockspresso instance is ensured (not just those required by real objects).
+- All dependencies are now created when the mockspresso instance is ensured (not just those required by real objects)
 
 ### v2.0.0 - Released 12/30/2022
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v2.0.1-SNAPSHOT - Unreleased
 
 - Update junit4 rule to ensure teardown is called even when the test fails/throws
+- All dependencies are now created when the mockspresso instance is ensured (not just those required by real objects).
 
 ### v2.0.0 - Released 12/30/2022
 


### PR DESCRIPTION
Currently, if you have a test setup where your real object is created on the fly, your dependencies and mocks declared in mockspresso wont exist until you touch them. This can lead to awkward scenarios when trying to setup mocks (especially with mockK).