### PR TITLE
[BREAKING CHANGE] Kill MockspressoBuilder, long live MockspressoProperties

### DIFF
--- a/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
@@ -55,7 +55,7 @@ interface MockspressoInstance {
    * This method will NOT ensure this [MockspressoInstance] is initialized (i.e. it's possible to build new mockspresso
    * instances off of lazily instantiated ones, and the parents will be ensured when first accessed).
    */
-  fun buildUpon(): Mockspresso
+  fun buildUpon(initBlock: MockspressoProperties.() -> Unit = {}): Mockspresso
 }
 
 /**

--- a/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
@@ -8,7 +8,7 @@ import com.episode6.mockspresso2.reflect.DependencyKey
 import com.episode6.mockspresso2.reflect.TypeToken
 
 /**
- * The main interface returned from a [MockspressoBuilder]. It implements [MockspressoInstance] but under the hood,
+ * The main interface of Mockspresso. It implements [MockspressoInstance] but under the hood,
  * the instance it implements is lazily initiated and doesn't become ensured/immutable until its dependencies are
  * accessed.
  *
@@ -50,9 +50,10 @@ interface MockspressoInstance {
   fun <T : Any?> findNow(key: DependencyKey<T>): T
 
   /**
-   * Returns a new [MockspressoBuilder] using this Mockspresso instance as a parent.
+   * Returns a new [Mockspresso] object using this Mockspresso instance as a parent. The new object will still
+   * be in builder-mode and can have new dependencies added to it even if the parent has already been ensured.
    *
-   * This method will NOT ensure this [MockspressoInstance] is initialized (i.e. it's possible to build new mockspresso
+   * This method will NOT ensure the receiver [MockspressoInstance] is initialized (i.e. it's possible to build new mockspresso
    * instances off of lazily instantiated ones, and the parents will be ensured when first accessed).
    */
   fun buildUpon(initBlock: MockspressoProperties.() -> Unit = {}): Mockspresso

--- a/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mockspresso2/Mockspresso.kt
@@ -55,78 +55,7 @@ interface MockspressoInstance {
    * This method will NOT ensure this [MockspressoInstance] is initialized (i.e. it's possible to build new mockspresso
    * instances off of lazily instantiated ones, and the parents will be ensured when first accessed).
    */
-  fun buildUpon(): MockspressoBuilder
-}
-
-/**
- * Builds a mockspresso [Mockspresso] instance that is lazily instantiated under the hood.
- */
-interface MockspressoBuilder {
-
-  /**
-   * Add a callback that will fire when the [MockspressoInstance] is fully instantiated/ensured.
-   */
-  fun onSetup(cmd: (MockspressoInstance) -> Unit): MockspressoBuilder
-
-  /**
-   * Add a callback that will fire when/if the [MockspressoInstance] is eventually torn down. (Automatic tear-down
-   * is not supported by default but can be configured using plugins).
-   */
-  fun onTeardown(cmd: () -> Unit): MockspressoBuilder
-
-  /**
-   * Define how this [MockspressoInstance] will construct real objects. By default, mockspresso will reflectively
-   * call the primary constructor of a given class and pass appropriate dependencies to it.
-   */
-  fun makeRealObjectsWith(realMaker: RealObjectMaker): MockspressoBuilder // formerly injector
-
-  /**
-   * Define how this [MockspressoInstance] will make fallback objects (i.e. dependencies that have not been explicitly
-   * registered/cached within this instance). Usually this should be supplied by one of the mocking support plugins
-   * (i.e. plugins-mockito or plugins-mockk).
-   *
-   * By default, mockspresso ships with a no-op [FallbackObjectMaker] that throws exceptions when called.
-   */
-  fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker): MockspressoBuilder // formerly mocker
-
-  /**
-   * Adds a [DynamicObjectMaker] to this [MockspressoInstance]. A [DynamicObjectMaker] gets a chance to supply any
-   * un-cached/undefined dependency before the request goes to the [FallbackObjectMaker]. This enables mockspresso
-   * plugins supply dependencies based on properties other than concrete types (i.e. generic types, class annotations,
-   * etc.). It also allows for "default" instances for bindings, which can be overridden by an explicit dependency.
-   */
-  fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder // formerly special object makers
-
-  /**
-   * Register a dependency provided by [provider], bound in the mockspresso graph with [key].
-   */
-  fun <T : Any?> dependency(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder
-
-  /**
-   * Register a request to create a real object of type [implementationToken] bound in the mockspresso graph with [key].
-   * The supplied [interceptor] lambda will be called when the real object is created and allows the test code to wrap
-   * the newly constructed real object before it's used. This enables the mock-support plugins to include spy support.
-   */
-  fun <BIND : Any?, IMPL : BIND> interceptRealImplementation(
-    key: DependencyKey<BIND>,
-    implementationToken: TypeToken<IMPL>,
-    interceptor: (IMPL) -> BIND = { it }
-  ): MockspressoBuilder
-
-  /**
-   * A utility method intended to enable the creation of shared "test resources" that can add to, pull from and
-   * define some kind of functionality within the injected dependencies of the mockspresso graph.
-   *
-   * The [maker] callback will be fired immediately when calling this method and does not wait for the instance to be
-   * ensured. This allows the test resources to add/configure dependencies in the graph.
-   */
-  fun testResources(maker: (MockspressoProperties) -> Unit): MockspressoBuilder
-
-  /**
-   * Build a [Mockspresso] object, but the actual [MockspressoInstance] will not be created immediately and will still
-   * be mutable until its ensured or its dependencies are accessed.
-   */
-  fun build(): Mockspresso
+  fun buildUpon(): Mockspresso
 }
 
 /**
@@ -149,6 +78,21 @@ interface MockspressoProperties {
    * is not supported by default but can be configured using plugins).
    */
   fun onTeardown(cmd: () -> Unit)
+
+  /**
+   * Define how this [MockspressoInstance] will construct real objects. By default, mockspresso will reflectively
+   * call the primary constructor of a given class and pass appropriate dependencies to it.
+   */
+  fun makeRealObjectsWith(realMaker: RealObjectMaker)
+
+  /**
+   * Define how this [MockspressoInstance] will make fallback objects (i.e. dependencies that have not been explicitly
+   * registered/cached within this instance). Usually this should be supplied by one of the mocking support plugins
+   * (i.e. plugins-mockito or plugins-mockk).
+   *
+   * By default, mockspresso ships with a no-op [FallbackObjectMaker] that throws exceptions when called.
+   */
+  fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker)
 
   /**
    * Adds a [DynamicObjectMaker] to this [MockspressoInstance]. A [DynamicObjectMaker] gets a chance to supply any

--- a/api/src/commonMain/kotlin/com/episode6/mockspresso2/MockspressoExt.kt
+++ b/api/src/commonMain/kotlin/com/episode6/mockspresso2/MockspressoExt.kt
@@ -26,40 +26,6 @@ inline fun <reified T : Any?> MockspressoInstance.findNow(
 /**
  * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
  * type [T] and [qualifier].
- */
-inline fun <reified T : Any?> MockspressoBuilder.dependency(
-  qualifier: Annotation? = null,
-  noinline provider: () -> T
-): MockspressoBuilder = dependency(dependencyKey<T>(qualifier)) { provider() }
-
-/**
- * Register a request to create a real object of type [T] bound in the mockspresso graph with a dependencyKey made from
- * type [T] and [qualifier].
- *
- * The supplied [init] lambda will be called when the real object is created.
- */
-inline fun <reified T : Any?> MockspressoBuilder.realInstance(
-  qualifier: Annotation? = null,
-  noinline init: T.() -> Unit = { }
-): MockspressoBuilder = dependencyKey<T>(qualifier).let { key ->
-  interceptRealImplementation(key, key.token) { it.apply(init) }
-}
-
-/**
- * Register a request to create a real object of type [IMPL] bound in the mockspresso graph with a dependencyKey made
- * from type [BIND] and [qualifier].
- *
- * The supplied [init] lambda will be called when the real object is created.
- */
-inline fun <reified BIND : Any?, reified IMPL : BIND> MockspressoBuilder.realImplementation(
-  qualifier: Annotation? = null,
-  noinline init: IMPL.() -> Unit = { }
-): MockspressoBuilder =
-  interceptRealImplementation(dependencyKey<BIND>(qualifier), typeToken<IMPL>()) { it.apply(init) }
-
-/**
- * Register a dependency provided by [provider], bound in the mockspresso graph with a dependencyKey made from
- * type [T] and [qualifier].
  *
  * Returns a [Lazy] with access to that dependency.
  *

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 allprojects {
   group = "com.episode6.mockspresso2"
-  version = "2.0.2-SNAPSHOT"
+  version = "2.1.0-SNAPSHOT"
 }
 description =
   "A testing tool designed to reduce friction, boiler-plate and brittleness in unit tests. It's like dependency injection for your tests!"

--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/Builder.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/Builder.kt
@@ -1,8 +1,15 @@
 package com.episode6.mockspresso2
 
-import com.episode6.mockspresso2.internal.MockspressoBuilderContainer
+import com.episode6.mockspresso2.internal.MockspressoContainer
+import com.episode6.mockspresso2.internal.MockspressoPropertiesContainer
+
 
 /**
- * Root entry point to create a new [MockspressoBuilder]
+ * Root entry point to create a new [Mockspresso] instance
  */
-fun MockspressoBuilder(): MockspressoBuilder = MockspressoBuilderContainer()
+fun Mockspresso(): Mockspresso = MockspressoContainer(MockspressoPropertiesContainer())
+
+/**
+ * Root entry point to create a new [Mockspresso] instance with a convenience apply block
+ */
+fun Mockspresso(initBlock: MockspressoProperties.() -> Unit): Mockspresso = Mockspresso().apply(initBlock)

--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
@@ -9,60 +9,23 @@ import com.episode6.mockspresso2.internal.util.mlazy
 import com.episode6.mockspresso2.reflect.DependencyKey
 import com.episode6.mockspresso2.reflect.TypeToken
 
-internal class MockspressoBuilderContainer(parent: Lazy<MxoInstance>? = null) : MockspressoBuilder {
+internal class MockspressoInstanceContainer(private val instance: MxoInstance) : MockspressoInstance {
+  override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
+  override fun <T> createNow(key: DependencyKey<T>): T = instance.create(key)
+  override fun buildUpon(): Mockspresso {
+    return MockspressoContainer(properties = MockspressoPropertiesContainer(parent = mlazy { instance }))
+  }
+}
+
+internal class MockspressoPropertiesContainer(parent: Lazy<MxoInstance>? = null) : MockspressoProperties {
 
   private var _builder: Lazy<MxoInstanceBuilder> = mlazy { MxoInstanceBuilder(parent) }
   private val builder: MxoInstanceBuilder get() = _builder.value
-  private val instanceLazy: Lazy<MxoInstance> = mlazy {
+  val instanceLazy: MxoInstance by mlazy {
     val builder = builder
     _builder = mlazy { throw MockspressoAlreadyInitializedError() }
     return@mlazy builder.build()
   }
-
-  private val properties = MockspressoPropertiesContainer(instanceLazy, getBuilder = { builder })
-
-  override fun onSetup(cmd: (MockspressoInstance) -> Unit): MockspressoBuilder =
-    apply { builder.onSetup(cmd) }
-
-  override fun onTeardown(cmd: () -> Unit): MockspressoBuilder =
-    apply { builder.onTearDown(cmd) }
-
-  override fun makeRealObjectsWith(realMaker: RealObjectMaker): MockspressoBuilder =
-    apply { builder.realObjectMaker(realMaker) }
-
-  override fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker): MockspressoBuilder =
-    apply { builder.addDynamicMaker(dynamicMaker) }
-
-  override fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker): MockspressoBuilder =
-    apply { builder.fallbackObjectMaker(fallbackMaker) }
-
-  override fun <T> dependency(key: DependencyKey<T>, provider: Dependencies.() -> T): MockspressoBuilder =
-    apply { builder.dependencyOf(key, provider) }
-
-  override fun <BIND : Any?, IMPL : BIND> interceptRealImplementation(
-    key: DependencyKey<BIND>,
-    implementationToken: TypeToken<IMPL>,
-    interceptor: (IMPL) -> BIND
-  ): MockspressoBuilder = apply { builder.realObject(key, implementationToken, interceptor) }
-
-  override fun testResources(maker: (MockspressoProperties) -> Unit): MockspressoBuilder =
-    apply { maker(properties) }
-
-  override fun build(): Mockspresso = MockspressoContainer(instanceLazy, properties)
-}
-
-internal class MockspressoInstanceContainer(private val instance: MxoInstance) : MockspressoInstance {
-  override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
-  override fun <T> createNow(key: DependencyKey<T>): T = instance.create(key)
-  override fun buildUpon(): MockspressoBuilder = MockspressoBuilderContainer(mlazy { instance })
-}
-
-private class MockspressoPropertiesContainer(
-  instanceLazy: Lazy<MxoInstance>,
-  private val getBuilder: () -> MxoInstanceBuilder,
-) : MockspressoProperties {
-  private val instance by instanceLazy
-  private val builder get() = getBuilder()
 
   override fun onSetup(cmd: (MockspressoInstance) -> Unit) {
     builder.onSetup(cmd)
@@ -70,6 +33,14 @@ private class MockspressoPropertiesContainer(
 
   override fun onTeardown(cmd: () -> Unit) {
     builder.onTearDown(cmd)
+  }
+
+  override fun makeRealObjectsWith(realMaker: RealObjectMaker) {
+    builder.realObjectMaker(realMaker)
+  }
+
+  override fun makeFallbackObjectsWith(fallbackMaker: FallbackObjectMaker) {
+    builder.fallbackObjectMaker(fallbackMaker)
   }
 
   override fun addDynamicObjectMaker(dynamicMaker: DynamicObjectMaker) {
@@ -88,16 +59,16 @@ private class MockspressoPropertiesContainer(
     interceptor: (IMPL) -> IMPL
   ): Lazy<IMPL> {
     builder.realObject(key, implementationToken, interceptor)
-    return mlazy { instance.get(key) as IMPL }
+    return mlazy { instanceLazy.get(key) as IMPL }
   }
 
-  override fun <T> findDependency(key: DependencyKey<T>): Lazy<T> = mlazy { instance.get(key) }
+  override fun <T> findDependency(key: DependencyKey<T>): Lazy<T> = mlazy { instanceLazy.get(key) }
 }
 
-private class MockspressoContainer(
-  private var instanceLazy: Lazy<MxoInstance>,
-  properties: MockspressoProperties,
+internal class MockspressoContainer constructor(
+  private val properties: MockspressoPropertiesContainer,
 ) : Mockspresso, MockspressoProperties by properties {
+  private var instanceLazy = mlazy { properties.instanceLazy }
   private val instance get() = instanceLazy.value
   override fun ensureInit() = instance.ensureInit()
   override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
@@ -108,5 +79,7 @@ private class MockspressoContainer(
     instanceLazy = mlazy { throw MockspressoAlreadyTornDownError() }
   }
 
-  override fun buildUpon(): MockspressoBuilder = MockspressoBuilderContainer(instanceLazy)
+  override fun buildUpon(): Mockspresso {
+    return MockspressoContainer(properties = MockspressoPropertiesContainer(parent = instanceLazy))
+  }
 }

--- a/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
+++ b/core/src/commonMain/kotlin/com/episode6/mockspresso2/internal/MockspressoContainers.kt
@@ -12,8 +12,9 @@ import com.episode6.mockspresso2.reflect.TypeToken
 internal class MockspressoInstanceContainer(private val instance: MxoInstance) : MockspressoInstance {
   override fun <T> findNow(key: DependencyKey<T>): T = instance.get(key)
   override fun <T> createNow(key: DependencyKey<T>): T = instance.create(key)
-  override fun buildUpon(): Mockspresso {
+  override fun buildUpon(initBlock: MockspressoProperties.() -> Unit): Mockspresso {
     return MockspressoContainer(properties = MockspressoPropertiesContainer(parent = mlazy { instance }))
+      .apply(initBlock)
   }
 }
 
@@ -79,7 +80,7 @@ internal class MockspressoContainer constructor(
     instanceLazy = mlazy { throw MockspressoAlreadyTornDownError() }
   }
 
-  override fun buildUpon(): Mockspresso {
-    return MockspressoContainer(properties = MockspressoPropertiesContainer(parent = instanceLazy))
+  override fun buildUpon(initBlock: MockspressoProperties.() -> Unit): Mockspresso {
+    return MockspressoContainer(properties = MockspressoPropertiesContainer(parent = instanceLazy)).apply(initBlock)
   }
 }

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/CircularDependencyTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/CircularDependencyTest.kt
@@ -11,10 +11,10 @@ import kotlin.test.Test
 class CircularDependencyTest {
 
   @Test fun testCircularDependency() {
-    val mxo = MockspressoBuilder()
-      .realInstance<A?>()
-      .realInstance<B?>()
-      .build()
+    val mxo = Mockspresso {
+      realInstance<A?>()
+      realInstance<B?>()
+    }
 
     val c by mxo.realImplementation<C?, C>()
 
@@ -24,9 +24,9 @@ class CircularDependencyTest {
   }
 
   @Test fun testWorksWhenChainIsBroken() {
-    val mxo = MockspressoBuilder()
-      .realInstance<A?>()
-      .build()
+    val mxo = Mockspresso {
+      realInstance<A?>()
+    }
 
     val b by mxo.dependency<B?> { B(null) }
     val c by mxo.realImplementation<C?, C>()
@@ -36,10 +36,10 @@ class CircularDependencyTest {
   }
 
   @Test fun testCircularDependency_stillFailsOnDynamicDependency() {
-    val mxo = MockspressoBuilder()
-      .realInstance<A?>()
-      .dependency<B?>(dependencyKey()) { B(get(dependencyKey())) }
-      .build()
+    val mxo = Mockspresso {
+      realInstance<A?>()
+      dependency<B?>(dependencyKey()) { B(get(dependencyKey())) }
+    }
 
     val c by mxo.realImplementation<C?, C>()
 

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/DynamicObjectMakerTest.kt
@@ -15,9 +15,9 @@ class DynamicObjectMakerTest {
   }
 
   @Test fun testUsageInBuilder() {
-    val mxo = MockspressoBuilder()
-      .addDynamicObjectMaker(defaultTestInterfaceMaker())
-      .build()
+    val mxo = Mockspresso {
+      addDynamicObjectMaker(defaultTestInterfaceMaker())
+    }
 
     val parent: TestParent by mxo.realImplementation()
 
@@ -25,10 +25,10 @@ class DynamicObjectMakerTest {
   }
 
   @Test fun testUsageInBuilder_override() {
-    val mxo = MockspressoBuilder()
-      .addDynamicObjectMaker(defaultTestInterfaceMaker())
-      .dependency<TestInterface> { TestObject("override") }
-      .build()
+    val mxo = Mockspresso {
+      addDynamicObjectMaker(defaultTestInterfaceMaker())
+      dependency<TestInterface> { TestObject("override") }
+    }
 
     val parent: TestParent by mxo.realImplementation()
 
@@ -36,7 +36,7 @@ class DynamicObjectMakerTest {
   }
 
   @Test fun testUsageInProperties() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     mxo.addDynamicObjectMaker(defaultTestInterfaceMaker())
     val parent: TestParent by mxo.realImplementation()
 
@@ -44,7 +44,7 @@ class DynamicObjectMakerTest {
   }
 
   @Test fun testUsageInProperties_override() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     mxo.addDynamicObjectMaker(defaultTestInterfaceMaker())
     val parent: TestParent by mxo.realImplementation()
     val override by mxo.dependency<TestInterface> { TestObject("override") }

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/EnsureInitWithNoInstanceTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/EnsureInitWithNoInstanceTest.kt
@@ -6,7 +6,7 @@ import assertk.assertions.isTrue
 import kotlin.test.Test
 
 class EnsureInitWithNoInstanceTest {
-  private val mxo = MockspressoBuilder().build()
+  private val mxo = Mockspresso()
 
   private var depCreated = false
   private val dep by mxo.dependency {
@@ -19,9 +19,9 @@ class EnsureInitWithNoInstanceTest {
   }
 
   @Test fun testEnsureInit() {
-   mxo.ensureInit()
+    mxo.ensureInit()
 
-   assertThat(depCreated).isTrue()
+    assertThat(depCreated).isTrue()
   }
 
   @Test fun testTouch() {

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/GenericDependenciesTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/GenericDependenciesTest.kt
@@ -8,11 +8,11 @@ import kotlin.test.Test
 class GenericDependenciesTest {
 
   @Test fun testSimpleGeneric() {
-    val mxo = MockspressoBuilder()
-      .dependency { 5 }
-      .dependency { "hello" }
-      .dependency { 4.2f }
-      .build()
+    val mxo = Mockspresso {
+      dependency { 5 }
+      dependency { "hello" }
+      dependency { 4.2f }
+    }
 
     val obj = mxo.createNow<GenericObj<String, Int, Float>>()
 
@@ -22,12 +22,12 @@ class GenericDependenciesTest {
   }
 
   @Test fun testGenericWithGeneric() {
-    val mxo = MockspressoBuilder()
-      .realInstance<GenericObj<Int, Float, Set<String>>>()
-      .dependency { 5 }
-      .dependency { setOf("str1", "str2") }
-      .dependency { 4.2f }
-      .build()
+    val mxo = Mockspresso {
+      realInstance<GenericObj<Int, Float, Set<String>>>()
+      dependency { 5 }
+      dependency { setOf("str1", "str2") }
+      dependency { 4.2f }
+    }
 
     val obj = mxo.createNow<GenericWithGeneric<Float, Int>>()
 
@@ -39,18 +39,18 @@ class GenericDependenciesTest {
   }
 
   @Test fun testRidiculousGenerics() {
-    val mxo = MockspressoBuilder()
-      .realInstance<GenericObj<List<Map<String, Int>>, Map<String, Int>, Set<String>>>()
-      .realInstance<GenericWithGeneric<Map<String, Int>, List<Map<String, Int>>>>()
-      .dependency { setOf("setStr1", "setStr2") }
-      .dependency { mapOf("str1" to 1) }
-      .dependency {
+    val mxo = Mockspresso {
+      realInstance<GenericObj<List<Map<String, Int>>, Map<String, Int>, Set<String>>>()
+      realInstance<GenericWithGeneric<Map<String, Int>, List<Map<String, Int>>>>()
+      dependency { setOf("setStr1", "setStr2") }
+      dependency { mapOf("str1" to 1) }
+      dependency {
         listOf(
           mapOf("str2" to 2),
           mapOf("str3" to 3)
         )
       }
-      .build()
+    }
 
     val obj = mxo.createNow<ConcreteWithGenerics>()
 

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/LifecycleTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/LifecycleTest.kt
@@ -18,12 +18,12 @@ class LifecycleTest {
   private val testDependency1: TestDependency1 = mockk(relaxUnitFun = true)
   private val testDependency2: TestDependency2 = mockk(relaxUnitFun = true)
 
-  private val mxo = MockspressoBuilder()
-    .onSetup(builderSetup)
-    .onTeardown(builderTeardown)
-    .dependency { testDependency1 }
-    .dependency { testDependency2 }
-    .build()
+  private val mxo = Mockspresso {
+    onSetup(builderSetup)
+    onTeardown(builderTeardown)
+    dependency { testDependency1 }
+    dependency { testDependency2 }
+  }
 
   init {
     mxo.onSetup(propSetup)
@@ -124,17 +124,25 @@ class LifecycleTest {
   private interface TestDependency1 {
     fun touch()
   }
+
   private interface TestDependency2 {
     fun touch()
   }
 
   // test obj calls dep during init, which lets us confirm if it's been constructed or not
   private class TestRealObj1(val dep: TestDependency1) {
-    init { dep.touch() }
+    init {
+      dep.touch()
+    }
+
     fun touch() {}
   }
+
   private class TestRealObj2(val dep: TestDependency2) {
-    init { dep.touch() }
+    init {
+      dep.touch()
+    }
+
     fun touch() {}
   }
 }

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/RealImplIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/RealImplIntegrationTest.kt
@@ -9,9 +9,9 @@ class RealImplIntegrationTest {
 
   @Test fun testRealImplOf() {
     val unexpectedTestClass = TestClass()
-    val mxo = MockspressoBuilder()
-      .dependency { unexpectedTestClass }
-      .build()
+    val mxo = Mockspresso {
+      dependency { unexpectedTestClass }
+    }
 
     val obj by mxo.realImplementation<TestInterface, TestClass>()
 

--- a/core/src/commonTest/kotlin/com/episode6/mockspresso2/SimpleIntegrationTest.kt
+++ b/core/src/commonTest/kotlin/com/episode6/mockspresso2/SimpleIntegrationTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.Test
 @Suppress("UNUSED_VARIABLE") // We need to hold refs to some values to set up our test cases. If these were real tests the vars would not be unused.
 class SimpleIntegrationTest {
   @Test fun testSimpleWorkingCase() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObject by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }
     val dep2 by mxo.dependency { SomeDependency2() }
@@ -23,7 +23,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testAccessDepFirst() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObject by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }
     val dep2 by mxo.dependency { SomeDependency2() }
@@ -36,7 +36,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testFailsWithMultipleDepsOfSameKey() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObject by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }
 
@@ -46,7 +46,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testFailsWithMultipleDepsOfSameKey_real_over_dep() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObject by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }
 
@@ -56,7 +56,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testMissingDeps() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObject by mxo.realInstance()
 
     assertThat {
@@ -65,7 +65,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testMultipleSameDepGetsSameInstance() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeBadObjectWithSameDepMultipleTimes by mxo.realInstance()
     val dep by mxo.dependency { SomeDependency1() }
 
@@ -75,7 +75,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testCreateRealObjectGetsNewInstances() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
 
     val obj1: SomeDependency1 = mxo.createNow()
     val obj2: SomeDependency1 = mxo.createNow()
@@ -84,7 +84,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testCreateRealObjectIsntCachedAsDep() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
 
     val obj1: SomeDependency1 = mxo.createNow()
 
@@ -94,9 +94,9 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testInterceptSpyk() {
-    val mxo = MockspressoBuilder()
-      .dependency { SomeDependency1() }
-      .build()
+    val mxo = Mockspresso {
+      dependency { SomeDependency1() }
+    }
 
     val dep2: SomeDependency2 by mxo.interceptRealImplementation(dependencyKey(), typeToken()) { spyk(it) }
     val objUnderTest: SomeObject by mxo.realInstance()
@@ -107,9 +107,9 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testDynamicDependency() {
-    val mxo = MockspressoBuilder()
-      .dependency(dependencyKey()) { SomeObject(get(dependencyKey()), get(dependencyKey())) }
-      .build()
+    val mxo = Mockspresso {
+      dependency(dependencyKey()) { SomeObject(get(dependencyKey()), get(dependencyKey())) }
+    }
 
     val dep1 by mxo.dependency { SomeDependency1() }
     val dep2 by mxo.dependency { SomeDependency2() }
@@ -120,7 +120,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testDynamicDependencyInProp() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
 
     val someObject by mxo.dependency(dependencyKey()) { SomeObject(get(dependencyKey()), get(dependencyKey())) }
     val dep1 by mxo.dependency { SomeDependency1() }
@@ -131,7 +131,7 @@ class SimpleIntegrationTest {
   }
 
   @Test fun testFakeOf() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
 
     val ro: SomeObjectWithIFaceDep by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }

--- a/core/src/jvmTest/kotlin/com/episode6/mockspresso2/QualifierIntegrationTest.kt
+++ b/core/src/jvmTest/kotlin/com/episode6/mockspresso2/QualifierIntegrationTest.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.full.createInstance
 class QualifierIntegrationTest {
 
   @Test fun testSimpleWorkingCaseWithQualifier() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeObjectWithQualifier by mxo.realInstance()
     val dep1 by mxo.dependency { SomeDependency1() }
     val dep2 by mxo.dependency(qualifier = SomeQualifier::class.createInstance()) { SomeDependency1() }
@@ -24,7 +24,7 @@ class QualifierIntegrationTest {
   }
 
   @Test fun testMultipleQualifiers() {
-    val mxo = MockspressoBuilder().build()
+    val mxo = Mockspresso()
     val objUnderTest: SomeBadObjectWithMultipleQualifiers by mxo.realInstance()
 
     assertThat { objUnderTest.doSomething() }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
   MockspressoBuilder are now on MockspressoProperties. This means we no longer need to duplicate extensions for both
   MockspressoBuilder and MockspressoProperties.
 
-  Before:
+Before:
 
 ```kotlin
 val mxo = MockspressoBuilder

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,16 +1,22 @@
 # ChangeLog
 
-### v2.1-SNAPSHOT - Unreleased
+### v2.1.0-SNAPSHOT - Unreleased
 
-- **BREAKING**: Simplified api and removed MockspressoBuilder completely. All methods that used to exist on the MockspressoBuilder are now on MockspressoProperties. This means we no longer need to duplicate extensions for both MockspressoBuilder and MockspressoProperties.
-   - Before:
+- **BREAKING**: Simplified api and removed MockspressoBuilder completely. All methods that used to exist on the
+  MockspressoBuilder are now on MockspressoProperties. This means we no longer need to duplicate extensions for both
+  MockspressoBuilder and MockspressoProperties.
+
+  Before:
+
 ```kotlin
 val mxo = MockspressoBuilder
   .makeRealObjectsWithPrimaryConstructor()
   .fallbackWithMockk()
   .build()
 ```
-   - After:
+
+After:
+
 ```kotlin
 val mxo = Mockspresso {
   makeRealObjectsWithPrimaryConstructor()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,22 @@
 # ChangeLog
 
-### v2.0.2-SNAPSHOT - Unreleased
+### v2.1-SNAPSHOT - Unreleased
 
+- **BREAKING**: Simplified api and removed MockspressoBuilder completely. All methods that used to exist on the MockspressoBuilder are now on MockspressoProperties. This means we no longer need to duplicate extensions for both MockspressoBuilder and MockspressoProperties.
+   - Before:
+```kotlin
+val mxo = MockspressoBuilder
+  .makeRealObjectsWithPrimaryConstructor()
+  .fallbackWithMockk()
+  .build()
+```
+   - After:
+```kotlin
+val mxo = Mockspresso {
+  makeRealObjectsWithPrimaryConstructor()
+  fallbackWithMockk()
+}
+```
 
 ### v2.0.1 - Released 3/9/2023
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v2.1.0-SNAPSHOT - Unreleased
 
-- **BREAKING**: Simplified api and removed MockspressoBuilder completely. All methods that used to exist on the
+- **BREAKING CHANGE**: Simplified api and removed MockspressoBuilder completely. All methods that used to exist on the
   MockspressoBuilder are now on MockspressoProperties. This means we no longer need to duplicate extensions for both
   MockspressoBuilder and MockspressoProperties.
 

--- a/plugins/core/src/commonMain/kotlin/com/episode6/mockspresso2/plugins/core/CorePlugins.kt
+++ b/plugins/core/src/commonMain/kotlin/com/episode6/mockspresso2/plugins/core/CorePlugins.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.core
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.plugins.core.reflect.reflectionRealObjectMaker
 import com.episode6.mockspresso2.reflect.allConstructors
 import com.episode6.mockspresso2.reflect.asKClass
@@ -10,20 +10,24 @@ import com.episode6.mockspresso2.reflect.primaryConstructor
 /**
  * Instruct this mockspresso instance to create real objects by calling their primary constructor.
  */
-fun MockspressoBuilder.makeRealObjectsUsingPrimaryConstructor(): MockspressoBuilder = makeRealObjectsWith(
-  reflectionRealObjectMaker { token.asKClass().primaryConstructor() }
-)
+fun MockspressoProperties.makeRealObjectsUsingPrimaryConstructor() {
+  makeRealObjectsWith(reflectionRealObjectMaker { token.asKClass().primaryConstructor() })
+}
 
 /**
  * Instruct this mockspresso instance to create real objects by calling the constructor with the fewest parameters.
  */
-fun MockspressoBuilder.makeRealObjectsUsingShortestConstructor(): MockspressoBuilder = makeRealObjectsWith(
-  reflectionRealObjectMaker { token.asKClass().allConstructors().minByOrNull { f -> f.parameterCount() }!! }
-)
+fun MockspressoProperties.makeRealObjectsUsingShortestConstructor() {
+  makeRealObjectsWith(
+    reflectionRealObjectMaker { token.asKClass().allConstructors().minByOrNull { f -> f.parameterCount() }!! }
+  )
+}
 
 /**
  * Instruct this mockspresso instance to create real objects by calling the constructor with the most parameters.
  */
-fun MockspressoBuilder.makeRealObjectsUsingLongestConstructor(): MockspressoBuilder = makeRealObjectsWith(
-  reflectionRealObjectMaker { token.asKClass().allConstructors().maxByOrNull { f -> f.parameterCount() }!! }
-)
+fun MockspressoProperties.makeRealObjectsUsingLongestConstructor() {
+  makeRealObjectsWith(
+    reflectionRealObjectMaker { token.asKClass().allConstructors().maxByOrNull { f -> f.parameterCount() }!! }
+  )
+}

--- a/plugins/dagger2/src/main/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2Plugins.kt
+++ b/plugins/dagger2/src/main/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2Plugins.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.dagger2
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.findExactlyOneInjectConstructor
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.javaxRealObjectMaker
 import dagger.assisted.AssistedInject
@@ -12,11 +12,15 @@ import kotlin.reflect.full.hasAnnotation
  * method injection. This is the same as javax.inject rules except we also accept the [AssistedInject] as a
  * valid constructor annotation.
  */
-fun MockspressoBuilder.makeRealObjectsUsingDagger2Rules(): MockspressoBuilder = makeRealObjectsWith(
-  javaxRealObjectMaker { findExactlyOneInjectConstructor { hasAnnotation<Inject>() || hasAnnotation<AssistedInject>() } }
-)
+fun MockspressoProperties.makeRealObjectsUsingDagger2Rules() {
+  makeRealObjectsWith(
+    javaxRealObjectMaker { findExactlyOneInjectConstructor { hasAnnotation<Inject>() || hasAnnotation<AssistedInject>() } }
+  )
+}
 
 /**
  * Enable automatic mapping of [dagger.Lazy]s to their underlying dependencies.
  */
-fun MockspressoBuilder.dagger2LazySupport(): MockspressoBuilder = addDynamicObjectMaker(dagger2LazyMaker())
+fun MockspressoProperties.dagger2LazySupport() {
+  addDynamicObjectMaker(dagger2LazyMaker())
+}

--- a/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2AssistedInjectRealObjectMakerTest.kt
+++ b/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2AssistedInjectRealObjectMakerTest.kt
@@ -2,7 +2,7 @@ package com.episode6.mockspresso2.plugins.dagger2
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import dagger.assisted.AssistedInject
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class Dagger2AssistedInjectRealObjectMakerTest {
 
   @Test fun testConstructorInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: ConstructorInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -22,7 +22,7 @@ class Dagger2AssistedInjectRealObjectMakerTest {
   }
 
   @Test fun testPropertyInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -32,7 +32,7 @@ class Dagger2AssistedInjectRealObjectMakerTest {
   }
 
   @Test fun testPropertySetInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesSetInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -42,7 +42,7 @@ class Dagger2AssistedInjectRealObjectMakerTest {
   }
 
   @Test fun testPropertyFieldInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesFieldInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -52,7 +52,7 @@ class Dagger2AssistedInjectRealObjectMakerTest {
   }
 
   @Test fun testMethodInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: MethodInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -69,14 +69,17 @@ class Dagger2AssistedInjectRealObjectMakerTest {
     @Inject lateinit var d1: Dependency1
     @Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesSetInject @AssistedInject constructor() {
     @set:Inject lateinit var d1: Dependency1
     @set:Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesFieldInject @AssistedInject constructor() {
     @field:Inject lateinit var d1: Dependency1
     @field:Inject lateinit var d2: Dependency2
   }
+
   private class MethodInject @AssistedInject constructor() {
     lateinit var d1: Dependency1
     lateinit var d2: Dependency2

--- a/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2BadInjectRealObjectMakerTest.kt
+++ b/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2BadInjectRealObjectMakerTest.kt
@@ -4,7 +4,7 @@ package com.episode6.mockspresso2.plugins.dagger2
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isFailure
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.MultipleInjectConstructorsException
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.NoInjectConstructorsException
 import com.episode6.mockspresso2.realInstance
@@ -15,28 +15,28 @@ import javax.inject.Inject
 class Dagger2BadInjectRealObjectMakerTest {
 
   @Test fun testNoConstructor() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: HasNoConstructor by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(NoInjectConstructorsException::class)
   }
 
   @Test fun testTooManyConstructors1() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: HasTooManyConstructors1 by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(MultipleInjectConstructorsException::class)
   }
 
   @Test fun testTooManyConstructors2() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: HasTooManyConstructors2 by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(MultipleInjectConstructorsException::class)
   }
 
   @Test fun testTooManyConstructors3() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: HasTooManyConstructors3 by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(MultipleInjectConstructorsException::class)

--- a/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2InjectRealObjectMakerTest.kt
+++ b/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2InjectRealObjectMakerTest.kt
@@ -2,7 +2,7 @@ package com.episode6.mockspresso2.plugins.dagger2
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class Dagger2InjectRealObjectMakerTest {
 
   @Test fun testConstructorInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: ConstructorInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -21,7 +21,7 @@ class Dagger2InjectRealObjectMakerTest {
   }
 
   @Test fun testPropertyInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -31,7 +31,7 @@ class Dagger2InjectRealObjectMakerTest {
   }
 
   @Test fun testPropertySetInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesSetInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -41,7 +41,7 @@ class Dagger2InjectRealObjectMakerTest {
   }
 
   @Test fun testPropertyFieldInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: PropertiesFieldInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -51,7 +51,7 @@ class Dagger2InjectRealObjectMakerTest {
   }
 
   @Test fun testMethodInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingDagger2Rules() }
     val ro: MethodInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -68,14 +68,17 @@ class Dagger2InjectRealObjectMakerTest {
     @Inject lateinit var d1: Dependency1
     @Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesSetInject @Inject constructor() {
     @set:Inject lateinit var d1: Dependency1
     @set:Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesFieldInject @Inject constructor() {
     @field:Inject lateinit var d1: Dependency1
     @field:Inject lateinit var d2: Dependency2
   }
+
   private class MethodInject @Inject constructor() {
     lateinit var d1: Dependency1
     lateinit var d2: Dependency2

--- a/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2LazyMakerTest.kt
+++ b/plugins/dagger2/src/test/kotlin/com/episode6/mockspresso2/plugins/dagger2/Dagger2LazyMakerTest.kt
@@ -2,7 +2,7 @@ package com.episode6.mockspresso2.plugins.dagger2
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import dagger.Lazy
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class Dagger2LazyMakerTest {
 
   @Test fun testObjWithProviders() {
-    val mxo = MockspressoBuilder().dagger2LazySupport().build()
+    val mxo = Mockspresso { dagger2LazySupport() }
     val ro: ObjWithProviders by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -22,7 +22,7 @@ class Dagger2LazyMakerTest {
   }
 
   @Test fun testGenericObjWithProviders() {
-    val mxo = MockspressoBuilder().dagger2LazySupport().build()
+    val mxo = Mockspresso { dagger2LazySupport() }
     val ro: GenericObjWithProviders<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -32,7 +32,10 @@ class Dagger2LazyMakerTest {
   }
 
   @Test fun testGenericObjWithProviders_inject() {
-    val mxo = MockspressoBuilder().dagger2LazySupport().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso {
+      dagger2LazySupport()
+      makeRealObjectsUsingDagger2Rules()
+    }
     val ro: GenericObjWithProvidersInject<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -42,7 +45,10 @@ class Dagger2LazyMakerTest {
   }
 
   @Test fun testSubclassGenericObjWithProviders_inject() {
-    val mxo = MockspressoBuilder().dagger2LazySupport().makeRealObjectsUsingDagger2Rules().build()
+    val mxo = Mockspresso {
+      dagger2LazySupport()
+      makeRealObjectsUsingDagger2Rules()
+    }
     val ro: SubclassOfGenericWithProviders<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }

--- a/plugins/javax-inject/src/main/kotlin/com/episode6/mockspresso2/plugins/javax/inject/JavaxInjectPlugins.kt
+++ b/plugins/javax-inject/src/main/kotlin/com/episode6/mockspresso2/plugins/javax/inject/JavaxInjectPlugins.kt
@@ -1,7 +1,7 @@
 package com.episode6.mockspresso2.plugins.javax.inject
 
-import com.episode6.mockspresso2.MockspressoBuilder
 import com.episode6.mockspresso2.MockspressoInstance
+import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.asDependencies
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.injectWithDependencies
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.javaxRealObjectMaker
@@ -12,13 +12,16 @@ import kotlin.reflect.full.createType
  * Make real objects using reflection according to java.inject rules. Supports constructor, property, field and
  * method injection.
  */
-fun MockspressoBuilder.makeRealObjectsUsingJavaxInjectRules(): MockspressoBuilder =
+fun MockspressoProperties.makeRealObjectsUsingJavaxInjectRules() {
   makeRealObjectsWith(javaxRealObjectMaker())
+}
 
 /**
  * Enable automatic mapping of [javax.inject.Provider]s to their underlying dependencies.
  */
-fun MockspressoBuilder.javaxProviderSupport(): MockspressoBuilder = addDynamicObjectMaker(javaxProviderMaker())
+fun MockspressoProperties.javaxProviderSupport() {
+  addDynamicObjectMaker(javaxProviderMaker())
+}
 
 /**
  * Perform field and method injection on an object that's been created outside the context of mockspresso.

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/BadInjectRealObjectMakerTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/BadInjectRealObjectMakerTest.kt
@@ -5,7 +5,7 @@ package com.episode6.mockspresso2.plugins.javax.inject
 import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isFailure
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.MultipleInjectConstructorsException
 import com.episode6.mockspresso2.plugins.javax.inject.reflect.NoInjectConstructorsException
 import com.episode6.mockspresso2.realInstance
@@ -15,14 +15,14 @@ import javax.inject.Inject
 class BadInjectRealObjectMakerTest {
 
   @Test fun testNoConstructor() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: HasNoConstructor by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(NoInjectConstructorsException::class)
   }
 
   @Test fun testTooManyConstructors() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: HasTooManyConstructors by mxo.realInstance()
 
     assertThat { mxo.ensureInit() }.isFailure().hasClass(MultipleInjectConstructorsException::class)

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/GenericRealObjectMakerTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/GenericRealObjectMakerTest.kt
@@ -3,7 +3,7 @@ package com.episode6.mockspresso2.plugins.javax.inject
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class GenericRealObjectMakerTest {
 
   @Test fun testSimpleDirectGeneric() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: GenericObj<String, Int, Long> by mxo.realInstance()
     val depA: String by mxo.dependency { "hi" }
     val depB: Int by mxo.dependency { 4 }
@@ -33,7 +33,7 @@ class GenericRealObjectMakerTest {
   }
 
   @Test fun testSimpleSubclassDirectGeneric() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: SubClass<String, Int, Long> by mxo.realInstance()
     val depC: String by mxo.dependency { "hi" }
     val depB: Int by mxo.dependency { 4 }
@@ -54,7 +54,7 @@ class GenericRealObjectMakerTest {
   }
 
   @Test fun testSimpleDirectGeneric_methodInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: GenericObjMethodInject<String, Int, Long> by mxo.realInstance()
     val depA: String by mxo.dependency { "hi" }
     val depB: Int by mxo.dependency { 4 }
@@ -75,7 +75,7 @@ class GenericRealObjectMakerTest {
   }
 
   @Test fun testSimpleSubclassDirectGeneric_methodInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: SubClassMethodInject<String, Int, Long> by mxo.realInstance()
     val depC: String by mxo.dependency { "hi" }
     val depB: Int by mxo.dependency { 4 }

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/JavaxInjectTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/JavaxInjectTest.kt
@@ -4,7 +4,7 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFailure
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.reflect.typeToken
 import org.junit.jupiter.api.Test
@@ -12,7 +12,7 @@ import javax.inject.Inject
 
 class JavaxInjectTest {
 
-  val mxo = MockspressoBuilder().build()
+  val mxo = Mockspresso()
 
   private val dep1 by mxo.dependency { Dependency1() }
   private val dep2 by mxo.dependency { Dependency2() }
@@ -94,7 +94,7 @@ class JavaxInjectTest {
     }
   }
 
-  private open class GenericInject<A: Any, B: Any> {
+  private open class GenericInject<A : Any, B : Any> {
     @Inject lateinit var d1: A
     @Inject lateinit var d2: B
   }

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/ProviderMakerTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/ProviderMakerTest.kt
@@ -2,7 +2,7 @@ package com.episode6.mockspresso2.plugins.javax.inject
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
@@ -12,7 +12,7 @@ import javax.inject.Provider
 class ProviderMakerTest {
 
   @Test fun testObjWithProviders() {
-    val mxo = MockspressoBuilder().javaxProviderSupport().build()
+    val mxo = Mockspresso { javaxProviderSupport() }
     val ro: ObjWithProviders by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -22,7 +22,7 @@ class ProviderMakerTest {
   }
 
   @Test fun testGenericObjWithProviders() {
-    val mxo = MockspressoBuilder().javaxProviderSupport().build()
+    val mxo = Mockspresso { javaxProviderSupport() }
     val ro: GenericObjWithProviders<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -32,7 +32,10 @@ class ProviderMakerTest {
   }
 
   @Test fun testGenericObjWithProviders_inject() {
-    val mxo = MockspressoBuilder().javaxProviderSupport().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso {
+      javaxProviderSupport()
+      makeRealObjectsUsingJavaxInjectRules()
+    }
     val ro: GenericObjWithProvidersInject<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -42,7 +45,10 @@ class ProviderMakerTest {
   }
 
   @Test fun testSubclassGenericObjWithProviders_inject() {
-    val mxo = MockspressoBuilder().javaxProviderSupport().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso {
+      javaxProviderSupport()
+      makeRealObjectsUsingJavaxInjectRules()
+    }
     val ro: SubclassOfGenericWithProviders<Dependency1, Dependency2> by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -64,5 +70,7 @@ class ProviderMakerTest {
     @Inject lateinit var a: Provider<A>
     @Inject lateinit var b: Provider<B>
   }
-  private class SubclassOfGenericWithProviders<B: Any, A: Any> @Inject constructor() : GenericObjWithProvidersInject<A, B>()
+
+  private class SubclassOfGenericWithProviders<B : Any, A : Any> @Inject constructor() :
+    GenericObjWithProvidersInject<A, B>()
 }

--- a/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/SimpleRealObjectMakerTest.kt
+++ b/plugins/javax-inject/src/test/kotlin/com/episode6/mockspresso2/plugins/javax/inject/SimpleRealObjectMakerTest.kt
@@ -2,7 +2,7 @@ package com.episode6.mockspresso2.plugins.javax.inject
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class SimpleRealObjectMakerTest {
 
   @Test fun testConstructorInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: ConstructorInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -21,7 +21,7 @@ class SimpleRealObjectMakerTest {
   }
 
   @Test fun testPropertyInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: PropertiesInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -31,7 +31,7 @@ class SimpleRealObjectMakerTest {
   }
 
   @Test fun testPropertySetInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: PropertiesSetInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -41,7 +41,7 @@ class SimpleRealObjectMakerTest {
   }
 
   @Test fun testPropertyFieldInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: PropertiesFieldInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -51,7 +51,7 @@ class SimpleRealObjectMakerTest {
   }
 
   @Test fun testJavaFieldInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: FieldInjectTestClass by mxo.realInstance()
     val d1 by mxo.dependency { FieldInjectTestClass.Dep1() }
     val d2 by mxo.dependency { FieldInjectTestClass.Dep2() }
@@ -61,7 +61,7 @@ class SimpleRealObjectMakerTest {
   }
 
   @Test fun testMethodInject() {
-    val mxo = MockspressoBuilder().makeRealObjectsUsingJavaxInjectRules().build()
+    val mxo = Mockspresso { makeRealObjectsUsingJavaxInjectRules() }
     val ro: MethodInject by mxo.realInstance()
     val d1 by mxo.dependency { Dependency1() }
     val d2 by mxo.dependency { Dependency2() }
@@ -78,14 +78,17 @@ class SimpleRealObjectMakerTest {
     @Inject lateinit var d1: Dependency1
     @Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesSetInject @Inject constructor() {
     @set:Inject lateinit var d1: Dependency1
     @set:Inject lateinit var d2: Dependency2
   }
+
   private class PropertiesFieldInject @Inject constructor() {
     @field:Inject lateinit var d1: Dependency1
     @field:Inject lateinit var d2: Dependency2
   }
+
   private class MethodInject @Inject constructor() {
     lateinit var d1: Dependency1
     lateinit var d2: Dependency2

--- a/plugins/junit4/src/test/kotlin/com/episode6/mockspresso2/plugins/junit4/JUnit4PluginsTest.kt
+++ b/plugins/junit4/src/test/kotlin/com/episode6/mockspresso2/plugins/junit4/JUnit4PluginsTest.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.junit4
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.MockspressoInstance
 import io.mockk.confirmVerified
 import io.mockk.mockk
@@ -13,10 +13,10 @@ class Junit4PluginsTest {
 
   private val setupCmd: (MockspressoInstance) -> Unit = mockk(relaxed = true)
   private val teardownCmd: () -> Unit = mockk(relaxed = true)
-  private val mxoRule = MockspressoBuilder()
-    .onSetup(setupCmd)
-    .onTeardown(teardownCmd)
-    .build().junitRule()
+  private val mxoRule = Mockspresso {
+    onSetup(setupCmd)
+    onTeardown(teardownCmd)
+  }.junitRule()
   private val baseStatement: Statement = mockk(relaxUnitFun = true)
   private val description: Description = mockk()
 

--- a/plugins/junit5/src/test/kotlin/com/episode6/mockspresso2/plugins/junit5/JUnit5ExtensionTest.kt
+++ b/plugins/junit5/src/test/kotlin/com/episode6/mockspresso2/plugins/junit5/JUnit5ExtensionTest.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.junit5
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.MockspressoInstance
 import io.mockk.confirmVerified
 import io.mockk.mockk
@@ -26,10 +26,11 @@ class JUnit5ExtensionTest {
       confirmVerified(setupCmd, teardownCmd)
     }
   }
-  @RegisterExtension val mxoExt = MockspressoBuilder()
-    .onSetup(setupCmd)
-    .onTeardown(teardownCmd)
-    .build().junitExtension()
+
+  @RegisterExtension val mxoExt = Mockspresso {
+    onSetup(setupCmd)
+    onTeardown(teardownCmd)
+  }.junitExtension()
 
   @Test fun testDuringTest() {
     verify { setupCmd.invoke(any()) }

--- a/plugins/junit5/src/test/kotlin/com/episode6/mockspresso2/plugins/junit5/JUnit5PluginsManualTest.kt
+++ b/plugins/junit5/src/test/kotlin/com/episode6/mockspresso2/plugins/junit5/JUnit5PluginsManualTest.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.junit5
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.MockspressoInstance
 import io.mockk.confirmVerified
 import io.mockk.mockk
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.extension.ExtensionContext
 class JUnit5PluginsManualTest {
   private val setupCmd: (MockspressoInstance) -> Unit = mockk(relaxed = true)
   private val teardownCmd: () -> Unit = mockk(relaxed = true)
-  private val mxoExt = MockspressoBuilder()
-    .onSetup(setupCmd)
-    .onTeardown(teardownCmd)
-    .build().junitExtension()
+  private val mxoExt = Mockspresso {
+    onSetup(setupCmd)
+    onTeardown(teardownCmd)
+  }.junitExtension()
   private val extensionContext: ExtensionContext = mockk()
 
   @Test fun verifyNoOpMeansNoOp() {

--- a/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryPlugins.kt
+++ b/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryPlugins.kt
@@ -1,6 +1,5 @@
 package com.episode6.mockspresso2.plugins.mockito.factories
 
-import com.episode6.mockspresso2.MockspressoBuilder
 import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.api.DynamicObjectMaker
 import com.episode6.mockspresso2.plugins.mockito.factories.reflect.autoFactoryMock
@@ -12,21 +11,13 @@ import kotlin.reflect.full.hasAnnotation
  * Marks any class encountered with the given [A] annotation as a Factory object. The object will be mocked and each
  * method will return a dependency from the underlying Mockspresso instance.
  */
-inline fun <reified A : Annotation> MockspressoBuilder.autoFactoriesByAnnotation(): MockspressoBuilder =
+inline fun <reified A : Annotation> MockspressoProperties.autoFactoriesByAnnotation() {
   addDynamicObjectMaker { key, deps ->
     when {
       key.token.asKClass().hasAnnotation<A>() -> DynamicObjectMaker.Answer.Yes(deps.autoFactoryMock(key))
       else                                    -> DynamicObjectMaker.Answer.No
     }
   }
-
-/*
- * Mark type [T] (with optional [qualifier]) as a Factory object. The object will be mocked and each method will return
- * a dependency from the underlying Mockspresso instance.
- */
-inline fun <reified T : Any?> MockspressoBuilder.autoFactory(qualifier: Annotation? = null): MockspressoBuilder {
-  val key = dependencyKey<T>(qualifier)
-  return dependency(key) { autoFactoryMock(key) }
 }
 
 /**

--- a/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
+++ b/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
@@ -1,7 +1,5 @@
 package com.episode6.mockspresso2.plugins.mockito.factories.reflect
 
-import com.episode6.mockspresso2.MockspressoBuilder
-import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.api.Dependencies
 import com.episode6.mockspresso2.reflect.DependencyKey
 import com.episode6.mockspresso2.reflect.asJClass
@@ -13,8 +11,7 @@ import org.mockito.stubbing.Answer
  * Returns a Factory object for the given [factoryKey]. The object will be mocked
  * and each method will return a dependency from the underlying Mockspresso instance.
  *
- * Generally you shouldn't need to access this method directly, prefer applying with [MockspressoBuilder.autoFactory]
- * or [MockspressoProperties.autoFactory]
+ * Generally you shouldn't need to access this method directly, prefer applying with MockspressoProperties.autoFactory
  */
 fun <T : Any?> Dependencies.autoFactoryMock(factoryKey: DependencyKey<T>): T =
   Mockito.mock(factoryKey.token.asJClass(), mockitoAutoFactoryAnswer(factoryKey))

--- a/plugins/mockito-factories/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryAnnotationTest.kt
+++ b/plugins/mockito-factories/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryAnnotationTest.kt
@@ -2,16 +2,16 @@ package com.episode6.mockspresso2.plugins.mockito.factories
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
 
 class MockitoAutoFactoryAnnotationTest {
 
-  val mxo = MockspressoBuilder()
-    .autoFactoriesByAnnotation<FactoryAnnotation>()
-    .build()
+  val mxo = Mockspresso {
+    autoFactoriesByAnnotation<FactoryAnnotation>()
+  }
 
   val ro by mxo.realInstance<RealObject>()
   val dep by mxo.dependency { Dependency() }

--- a/plugins/mockito-factories/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryClassBuilderTest.kt
+++ b/plugins/mockito-factories/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/MockitoAutoFactoryClassBuilderTest.kt
@@ -2,16 +2,16 @@ package com.episode6.mockspresso2.plugins.mockito.factories
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.dependency
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
 
 class MockitoAutoFactoryClassBuilderTest {
 
-  val mxo = MockspressoBuilder()
-    .autoFactory<DependencyFactory>()
-    .build()
+  val mxo = Mockspresso {
+    autoFactory<DependencyFactory>()
+  }
 
   val ro by mxo.realInstance<RealObject>()
   val dep by mxo.dependency { Dependency() }

--- a/plugins/mockito/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoPlugins.kt
+++ b/plugins/mockito/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoPlugins.kt
@@ -1,6 +1,5 @@
 package com.episode6.mockspresso2.plugins.mockito
 
-import com.episode6.mockspresso2.MockspressoBuilder
 import com.episode6.mockspresso2.MockspressoProperties
 import com.episode6.mockspresso2.api.FallbackObjectMaker
 import com.episode6.mockspresso2.dependency
@@ -22,88 +21,10 @@ import kotlin.reflect.KClass
 /**
  * Use mockito to generate fallback objects for dependencies that are not present in the mockspresso instance
  */
-fun MockspressoBuilder.fallbackWithMockito(): MockspressoBuilder =
+fun MockspressoProperties.fallbackWithMockito() {
   makeFallbackObjectsWith(object : FallbackObjectMaker {
     override fun <T> makeObject(key: DependencyKey<T>): T = Mockito.mock(key.token.asJClass())
   })
-
-/**
- * Add a mock with the supplied params as a dependency in this mockspresso instance. Mock will be bound with the
- * supplied qualifier annotation. If you need a reference to the mock dependency, consider [MockspressoProperties.mock]
- * instead.
- */
-inline fun <reified T : Any?> MockspressoBuilder.mock(
-  qualifier: Annotation? = null,
-  extraInterfaces: Array<out KClass<out Any>>? = null,
-  name: String? = null,
-  spiedInstance: Any? = null,
-  defaultAnswer: Answer<Any>? = null,
-  serializable: Boolean = false,
-  serializableMode: SerializableMode? = null,
-  verboseLogging: Boolean = false,
-  invocationListeners: Array<InvocationListener>? = null,
-  stubOnly: Boolean = false,
-  @Incubating useConstructor: UseConstructor? = null,
-  @Incubating outerInstance: Any? = null,
-  @Incubating lenient: Boolean = false
-): MockspressoBuilder = dependency(qualifier) {
-  Mockito.mock(
-    T::class.java,
-    withSettings(
-      extraInterfaces = extraInterfaces,
-      name = name,
-      spiedInstance = spiedInstance,
-      defaultAnswer = defaultAnswer,
-      serializable = serializable,
-      serializableMode = serializableMode,
-      verboseLogging = verboseLogging,
-      invocationListeners = invocationListeners,
-      stubOnly = stubOnly,
-      useConstructor = useConstructor,
-      outerInstance = outerInstance,
-      lenient = lenient
-    )
-  )!!
-}
-
-/**
- * Add a mock with the supplied params as a dependency in this mockspresso instance. Mock will be bound with the
- * supplied qualifier annotation. If you need a reference to the mock dependency, consider [MockspressoProperties.mock]
- * instead.
- */
-inline fun <reified T : Any?> MockspressoBuilder.mock(
-  qualifier: Annotation? = null,
-  extraInterfaces: Array<out KClass<out Any>>? = null,
-  name: String? = null,
-  spiedInstance: Any? = null,
-  defaultAnswer: Answer<Any>? = null,
-  serializable: Boolean = false,
-  serializableMode: SerializableMode? = null,
-  verboseLogging: Boolean = false,
-  invocationListeners: Array<InvocationListener>? = null,
-  stubOnly: Boolean = false,
-  @Incubating useConstructor: UseConstructor? = null,
-  @Incubating outerInstance: Any? = null,
-  @Incubating lenient: Boolean = false,
-  noinline stubbing: KStubbing<T>.(T) -> Unit
-): MockspressoBuilder = dependency(qualifier) {
-  Mockito.mock(
-    T::class.java,
-    withSettings(
-      extraInterfaces = extraInterfaces,
-      name = name,
-      spiedInstance = spiedInstance,
-      defaultAnswer = defaultAnswer,
-      serializable = serializable,
-      serializableMode = serializableMode,
-      verboseLogging = verboseLogging,
-      invocationListeners = invocationListeners,
-      stubOnly = stubOnly,
-      useConstructor = useConstructor,
-      outerInstance = outerInstance,
-      lenient = lenient
-    )
-  ).apply { KStubbing(this).stubbing(this) }!!
 }
 
 /**

--- a/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoFallbackMakerTest.kt
+++ b/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoFallbackMakerTest.kt
@@ -1,7 +1,7 @@
 package com.episode6.mockspresso2.plugins.mockito
 
 import assertk.assertThat
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.inOrder
@@ -9,9 +9,9 @@ import org.mockito.kotlin.verify
 
 class MockitoFallbackMakerTest {
 
-  val mxo = MockspressoBuilder()
-    .fallbackWithMockito()
-    .build()
+  val mxo = Mockspresso {
+    fallbackWithMockito()
+  }
 
   private val realObject: TestObj by mxo.realInstance()
   private val realObjectWithNullable: TestObjNullable by mxo.realInstance()

--- a/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoMockingTest.kt
+++ b/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoMockingTest.kt
@@ -3,7 +3,7 @@ package com.episode6.mockspresso2.plugins.mockito
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.*
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doThrow
@@ -12,11 +12,11 @@ import org.mockito.kotlin.verify
 
 class MockitoMockingTest {
 
-  val mxo = MockspressoBuilder()
-    .mock<TestDepOne> {
+  val mxo = Mockspresso {
+    mock<TestDepOne> {
       on { doSomething() } doThrow RuntimeException()
     }
-    .build()
+  }
 
   private val realObject: TestObj by mxo.realInstance()
   private val dep2: TestDepTwo by mxo.mock()

--- a/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoSpyingTest.kt
+++ b/plugins/mockito/src/test/kotlin/com/episode6/mockspresso2/plugins/mockito/MockitoSpyingTest.kt
@@ -4,14 +4,14 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.inOrder
 
 class MockitoSpyingTest {
 
-  val mxo = MockspressoBuilder().build()
+  val mxo = Mockspresso()
 
   private val realObject: TestObj by mxo.realInstance()
   private val dep1: TestDepOne by mxo.spy()

--- a/plugins/mockk/src/commonMain/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkPlugins.kt
+++ b/plugins/mockk/src/commonMain/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkPlugins.kt
@@ -18,44 +18,22 @@ import io.mockk.spyk as _spyk
  * Use mockk to generate fallback objects for dependencies that are not present in the mockspresso instance
  */
 @Suppress("UNCHECKED_CAST")
-fun MockspressoBuilder.fallbackWithMockk(
+fun MockspressoProperties.fallbackWithMockk(
   relaxed: Boolean = true,
   relaxedUnitFun: Boolean = true,
-): MockspressoBuilder = makeFallbackObjectsWith(object : FallbackObjectMaker {
-  // we're duplicating internal mockk code here to support creating generic mocks based on a [DependencyKey]
-  override fun <T> makeObject(key: DependencyKey<T>): T = MockK.useImpl {
-    MockKGateway.implementation().mockFactory.mockk(
-      mockType = key.token.asKClass(),
-      name = "automock:$key",
-      relaxed = relaxed,
-      moreInterfaces = emptyArray(),
-      relaxUnitFun = relaxedUnitFun,
-    ) as T
-  }
-})
-
-/**
- * Add a mockk with the supplied params as a dependency in this mockspresso instance. Mock will be bound with the
- * supplied qualifier annotation. If you need a reference to the mock dependency, consider [MockspressoProperties.mockk]
- * instead.
- *
- * IMPORTANT: we default [relaxed] and [relaxUnitFun] to true for defaultMocks.
- */
-inline fun <reified T : Any?> MockspressoBuilder.mockk(
-  qualifier: Annotation? = null,
-  name: String? = null,
-  relaxed: Boolean = true,
-  vararg moreInterfaces: KClass<*>,
-  relaxUnitFun: Boolean = true,
-  noinline block: T.() -> Unit = {}
-) = dependency<T>(qualifier) {
-  _mockk(
-    name = name,
-    relaxed = relaxed,
-    moreInterfaces = *moreInterfaces,
-    relaxUnitFun = relaxUnitFun,
-    block = block
-  )
+) {
+  makeFallbackObjectsWith(object : FallbackObjectMaker {
+    // we're duplicating internal mockk code here to support creating generic mocks based on a [DependencyKey]
+    override fun <T> makeObject(key: DependencyKey<T>): T = MockK.useImpl {
+      MockKGateway.implementation().mockFactory.mockk(
+        mockType = key.token.asKClass(),
+        name = "automock:$key",
+        relaxed = relaxed,
+        moreInterfaces = emptyArray(),
+        relaxUnitFun = relaxedUnitFun,
+      ) as T
+    }
+  })
 }
 
 /**

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkFallbackMakerTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkFallbackMakerTest.kt
@@ -1,6 +1,6 @@
 package com.episode6.mockspresso2.plugins.mockk
 
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import io.mockk.verify
 import io.mockk.verifyOrder
@@ -8,9 +8,9 @@ import kotlin.test.Test
 
 class MockkFallbackMakerTest {
 
-  val mxo = MockspressoBuilder()
-    .fallbackWithMockk()
-    .build()
+  val mxo = Mockspresso {
+    fallbackWithMockk()
+  }
 
   private val realObject: TestObj by mxo.realInstance()
   private val realObjectWithNullable: TestObjNullable by mxo.realInstance()
@@ -27,7 +27,7 @@ class MockkFallbackMakerTest {
 
   @Test fun testCanCallMockOnNullableDep() {
     realObjectWithNullable.nullableDep!!.doSomethingElse()
-    
+
     verify { realObjectWithNullable.nullableDep!!.doSomethingElse() }
   }
 

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkMockingTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkMockingTest.kt
@@ -2,8 +2,11 @@ package com.episode6.mockspresso2.plugins.mockk
 
 import assertk.all
 import assertk.assertThat
-import assertk.assertions.*
-import com.episode6.mockspresso2.MockspressoBuilder
+import assertk.assertions.hasClass
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFailure
+import assertk.assertions.isNotNull
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import io.mockk.every
 import io.mockk.verify
@@ -12,11 +15,11 @@ import kotlin.test.Test
 
 class MockkMockingTest {
 
-  val mxo = MockspressoBuilder()
-    .mockk<TestDepOne> {
+  val mxo = Mockspresso {
+    mockk<TestDepOne> {
       every { doSomething() } throws RuntimeException()
     }
-    .build()
+  }
 
   private val realObject: TestObj by mxo.realInstance()
   private val dep2: TestDepTwo by mxo.mockk(relaxed = true)

--- a/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkSpyingTest.kt
+++ b/plugins/mockk/src/commonTest/kotlin/com/episode6/mockspresso2/plugins/mockk/MockkSpyingTest.kt
@@ -4,14 +4,14 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
-import com.episode6.mockspresso2.MockspressoBuilder
+import com.episode6.mockspresso2.Mockspresso
 import com.episode6.mockspresso2.realInstance
 import io.mockk.verifyOrder
 import kotlin.test.Test
 
 class MockkSpyingTest {
 
-  val mxo = MockspressoBuilder().build()
+  val mxo = Mockspresso()
 
   private val realObject: TestObj by mxo.realInstance()
   private val dep1: TestDepOne by mxo.spyk()


### PR DESCRIPTION
## This is a major breaking change to the api!

- Copy the `makeRealObjectsWith` and `makeFallbackObjectsWith` method from MockspressoBuilder -> MockspressoProperties (these were the only two methods missing from MockspressoProperties)
- Delete the MockspressoBuilder
- Update all extension methods that were referencing MockspressoBuilder and either replace with MockspressoProperties or delete if a verison already exists on MockspressoProperties
- Delete old entry point and replace with a function `fun Mockspresso(initBlock: MockspressoProperties.()->): Mockspresso`

New syntax looks like this
```kotlin
val mxo = Mockspresso {
  makeRealObjectsWithPrimaryConstructor()
  makeFallbacksWithMockito()
  mock<SomeObject> {
    //some stubbing
  }
  // etc
}
```