### PR TITLE
Register .agents skills under .claude/skills for harness auto-trigger

### DIFF
--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -1,3 +1,14 @@
+---
+name: release-branch-skill
+description: >-
+  Cut a new release branch and prepare the version-bump PRs, as defined in
+  RELEASE_CHECKLIST.md. Use whenever the user asks to "cut a release branch"
+  (or to cut/create/start a new release branch): verifies main is green,
+  creates release/v<VERSION>, and opens the snapshot-on-main and
+  release-on-branch version-bump PRs that update build.gradle.kts and
+  docs/CHANGELOG.md.
+---
+
 # Cut Release Branch Skill
 
 This skill automates and describes the process of cutting a new release branch and preparing the version bumps, as defined in `RELEASE_CHECKLIST.md`.

--- a/.agents/update-docs-skill/SKILL.md
+++ b/.agents/update-docs-skill/SKILL.md
@@ -1,3 +1,12 @@
+---
+name: update-docs-skill
+description: >-
+  Policy and automation requiring changelog/docs updates whenever code changes
+  are made. Use when updating docs or the changelog for a change, or to verify a
+  branch's code changes are accompanied by docs/CHANGELOG/README updates. Runs
+  scripts/verify-docs-updated.sh; enforced in CI by .github/workflows/verify-docs.yml.
+---
+
 # Enforce Docs & Changelog Updates Skill
 
 Purpose

--- a/.claude/skills/release-branch-skill
+++ b/.claude/skills/release-branch-skill
@@ -1,0 +1,1 @@
+../../.agents/release-branch-skill

--- a/.claude/skills/ship-release-skill
+++ b/.claude/skills/ship-release-skill
@@ -1,0 +1,1 @@
+../../.agents/ship-release-skill

--- a/.claude/skills/update-docs-skill
+++ b/.claude/skills/update-docs-skill
@@ -1,0 +1,1 @@
+../../.agents/update-docs-skill

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,5 @@ This is a Kotlin Multiplatform project targeting JVM only. Key modules:
 ## Skills
 
 See `.agents/` for available skills:
-- `.agents/release-branch-skill/` — create a release branch
+- `.agents/release-branch-skill/` — cut/create a new release branch (e.g. "cut a release branch"); also registered under `.claude/skills/` for auto-trigger
 - `.agents/ship-release-skill/` — ship a release


### PR DESCRIPTION
## What

Makes the three `.agents/*-skill` skills discoverable by the Claude Code harness so the Skill tool auto-triggers them on natural phrasing (e.g. "cut a release branch").

## Why

The harness only auto-discovers skills under `.claude/skills/` (or `~/.claude/skills/`, or plugins). The `.agents/` skills were only referenced softly via `AGENTS.md`, so they never appeared in the Skill tool's registry.

## Changes

- **Symlink** `release-branch-skill`, `ship-release-skill`, `update-docs-skill` from `.claude/skills/` → `.agents/` (source of truth stays in `.agents/`).
- **Add YAML frontmatter** (`name`/`description`) to `release-branch-skill` and `update-docs-skill` SKILL.md so the harness has trigger descriptions. `ship-release-skill` already had it.
- **AGENTS.md**: reworded the `release-branch-skill` pointer to include "cut a release branch" and note the `.claude/skills/` registration.

## Note

Skills are registered at session start, so the auto-trigger takes effect in a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)