### PR TITLE
[VERSION] Release v2.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
   group = "com.episode6.mockspresso2"
-  version = "2.1.0-SNAPSHOT"
+  version = "2.1.0"
 }
 description =
   "A testing tool designed to reduce friction, boiler-plate and brittleness in unit tests. It's like dependency injection for your tests!"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-### v2.1.0-SNAPSHOT - Unreleased
+### v2.1.0 - Released 6/21/2026
 
 - Upgrade Kotlin 1.7.10 -> 2.3.21 (explicit API mode; all public declarations now require an explicit `public` modifier)
 - Upgrade Gradle wrapper 7.5.1 -> 9.5.1 (lazy task registration, `layout.buildDirectory`, explicit junit-platform-launcher dependency)


### PR DESCRIPTION
Finalizes the version to `2.1.0` on the release branch.

- Updates `version` in `build.gradle.kts` to `2.1.0` (removes `-SNAPSHOT`)
- Stamps `v2.1.0` with its release date (`6/21/2026`) in `docs/CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrWWSJk9Ez9WYxvvp9joVQ