### PR TITLE
Fix ship-release.py to match ### changelog header convention

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### v2.2.0-SNAPSHOT - Unreleased
 
+- Fix `ship-release.py` to parse `### v<VERSION>` changelog headers (was incorrectly looking for `##`)
+
 ### v2.1.0 - Released 6/21/2026
 
 - Upgrade Kotlin 1.7.10 -> 2.3.21 (explicit API mode; all public declarations now require an explicit `public` modifier)

--- a/scripts/ship-release.py
+++ b/scripts/ship-release.py
@@ -55,9 +55,9 @@ def get_changelog_notes(version):
     notes = []
     found_section = False
     
-    # We look for a line starting with '## v<version>'
-    header_pattern = re.compile(rf"^##\s+v{re.escape(version)}(\s+|$|-)")
-    any_header_pattern = re.compile(r"^##\s+v\d+")
+    # We look for a line starting with '### v<version>'
+    header_pattern = re.compile(rf"^###\s+v{re.escape(version)}(\s+|$|-)")
+    any_header_pattern = re.compile(r"^###\s+v\d+")
     
     for line in lines:
         if found_section:


### PR DESCRIPTION
## Summary
- `ship-release.py` was parsing `## v<VERSION>` (double-hash) but every entry in `docs/CHANGELOG.md` uses `### v<VERSION>` (triple-hash)
- This caused `ship-release.py --dry-run` to fail with "Could not find changelog section" when attempting to ship release/v2.1.0
- Changelog updated under v2.2.0-SNAPSHOT

## Test plan
- [ ] `./scripts/ship-release.py --dry-run --output /tmp/dry-run.json` succeeds on the release branch after cherry-picking this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6bWUYm2LYqETsa7PeA6D