### PR TITLE
Cherry-pick: Fix ship-release.py to match ### changelog header convention

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v2.1.0 - Released 6/21/2026
 
+- Fix `ship-release.py` to parse `### v<VERSION>` changelog headers (was incorrectly looking for `##`)
 - Upgrade Kotlin 1.7.10 -> 2.3.21 (explicit API mode; all public declarations now require an explicit `public` modifier)
 - Upgrade Gradle wrapper 7.5.1 -> 9.5.1 (lazy task registration, `layout.buildDirectory`, explicit junit-platform-launcher dependency)
 - Upgrade Dokka 1.7.10 -> 2.2.0 with the new aggregation model

--- a/scripts/ship-release.py
+++ b/scripts/ship-release.py
@@ -55,9 +55,9 @@ def get_changelog_notes(version):
     notes = []
     found_section = False
     
-    # We look for a line starting with '## v<version>'
-    header_pattern = re.compile(rf"^##\s+v{re.escape(version)}(\s+|$|-)")
-    any_header_pattern = re.compile(r"^##\s+v\d+")
+    # We look for a line starting with '### v<version>'
+    header_pattern = re.compile(rf"^###\s+v{re.escape(version)}(\s+|$|-)")
+    any_header_pattern = re.compile(r"^###\s+v\d+")
     
     for line in lines:
         if found_section:


### PR DESCRIPTION
## Summary
Cherry-pick of #118 into `release/v2.1.0`.

- Fixes `ship-release.py` to parse `### v<VERSION>` headers (was looking for `##`)
- Conflict in `docs/CHANGELOG.md` resolved by dropping the `v2.2.0-SNAPSHOT` section and placing the entry under `v2.1.0` instead

## Test plan
- [ ] `./scripts/ship-release.py --dry-run --output /tmp/dry-run.json` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6bWUYm2LYqETsa7PeA6D