### PR TITLE
Fix Dokka unresolved link warnings in autoFactoryMock KDoc

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v2.2.0-SNAPSHOT - Unreleased
 
 - Fix `ship-release.py` to parse `### v<VERSION>` changelog headers (was incorrectly looking for `##`)
+- Fix broken Dokka KDoc links in `autoFactoryMock` (fully-qualify cross-package references to `autoFactory` extensions)
 
 ### v2.1.0 - Released 6/21/2026
 

--- a/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
+++ b/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
@@ -13,8 +13,9 @@ import org.mockito.stubbing.Answer
  * Returns a Factory object for the given [factoryKey]. The object will be mocked
  * and each method will return a dependency from the underlying Mockspresso instance.
  *
- * Generally you shouldn't need to access this method directly, prefer applying with [MockspressoBuilder.autoFactory]
- * or [MockspressoProperties.autoFactory]
+ * Generally you shouldn't need to access this method directly, prefer applying with
+ * [MockspressoBuilder.autoFactory][com.episode6.mockspresso2.plugins.mockito.factories.autoFactory]
+ * or [MockspressoProperties.autoFactory][com.episode6.mockspresso2.plugins.mockito.factories.autoFactory]
  */
 public fun <T : Any?> Dependencies.autoFactoryMock(factoryKey: DependencyKey<T>): T =
   Mockito.mock(factoryKey.token.asJClass(), mockitoAutoFactoryAnswer(factoryKey))


### PR DESCRIPTION
## Summary
- `dokkaGenerateHtml` was emitting `Couldn't resolve link` warnings for `[MockspressoBuilder.autoFactory]` and `[MockspressoProperties.autoFactory]` in `MockitoAutoFactory.kt`
- Root cause: those extension functions live in the parent package (`com.episode6.mockspresso2.plugins.mockito.factories`), so simple unqualified KDoc links can't be resolved from the subpackage
- Fix: use `[display text][fully.qualified.reference]` KDoc syntax to cross-package link correctly

## Test plan
- [ ] `./gradlew dokkaGenerateHtml` produces no `Couldn't resolve link` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6bWUYm2LYqETsa7PeA6D