### PR TITLE
Cherry-pick: Fix Dokka unresolved link warnings in autoFactoryMock KDoc

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v2.1.0 - Released 6/21/2026
 
 - Fix `ship-release.py` to parse `### v<VERSION>` changelog headers (was incorrectly looking for `##`)
+- Fix broken Dokka KDoc links in `autoFactoryMock` (fully-qualify cross-package references to `autoFactory` extensions)
 - Upgrade Kotlin 1.7.10 -> 2.3.21 (explicit API mode; all public declarations now require an explicit `public` modifier)
 - Upgrade Gradle wrapper 7.5.1 -> 9.5.1 (lazy task registration, `layout.buildDirectory`, explicit junit-platform-launcher dependency)
 - Upgrade Dokka 1.7.10 -> 2.2.0 with the new aggregation model

--- a/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
+++ b/plugins/mockito-factories/src/main/kotlin/com/episode6/mockspresso2/plugins/mockito/factories/reflect/MockitoAutoFactory.kt
@@ -13,8 +13,9 @@ import org.mockito.stubbing.Answer
  * Returns a Factory object for the given [factoryKey]. The object will be mocked
  * and each method will return a dependency from the underlying Mockspresso instance.
  *
- * Generally you shouldn't need to access this method directly, prefer applying with [MockspressoBuilder.autoFactory]
- * or [MockspressoProperties.autoFactory]
+ * Generally you shouldn't need to access this method directly, prefer applying with
+ * [MockspressoBuilder.autoFactory][com.episode6.mockspresso2.plugins.mockito.factories.autoFactory]
+ * or [MockspressoProperties.autoFactory][com.episode6.mockspresso2.plugins.mockito.factories.autoFactory]
  */
 public fun <T : Any?> Dependencies.autoFactoryMock(factoryKey: DependencyKey<T>): T =
   Mockito.mock(factoryKey.token.asJClass(), mockitoAutoFactoryAnswer(factoryKey))


### PR DESCRIPTION
## Summary
Cherry-pick of #120 into `release/v2.1.0`.

- Fully-qualifies KDoc cross-package links in `autoFactoryMock` to silence `Couldn't resolve link` Dokka warnings
- Conflict in `docs/CHANGELOG.md` resolved by dropping the `v2.2.0-SNAPSHOT` section and placing the entry under `v2.1.0`

## Test plan
- [ ] `./gradlew dokkaGenerateHtml` produces no `Couldn't resolve link` warnings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BM6bWUYm2LYqETsa7PeA6D