### PR TITLE
Constrain snapshot version bump to patch-only in release-branch-skill

### DIFF
--- a/.agents/release-branch-skill/SKILL.md
+++ b/.agents/release-branch-skill/SKILL.md
@@ -30,7 +30,7 @@ Create two separate Pull Requests to update versions.
 - **Target Branch:** `main`
 - **PR Title:** `[VERSION] Snapshot v<NEXT_VERSION>-SNAPSHOT`
 - **Changes:**
-    - Update `version` in `build.gradle.kts`.
+    - Update `version` in `build.gradle.kts`. **(VITAL)** When computing `<NEXT_VERSION>`, increment **only the patch version** (e.g., `2.2.0` → `2.2.1`). Never automatically increment the major or minor version — those bumps require explicit human decision.
     - **(VITAL)** Update `docs/CHANGELOG.md` to include a new "Unreleased" section for the next version, AND update the version being released with its release date.
 
 #### PR 2: Release Version on Release Branch


### PR DESCRIPTION
## Summary
- Updates the `release-branch-skill` SKILL.md to explicitly require that only the **patch version** is incremented when creating the snapshot version bump PR on `main`.
- Marks major and minor version increments as requiring an explicit human decision — the agent must never auto-increment them.

## Test plan
- [ ] Review the updated SKILL.md wording to confirm it clearly constrains the agent's behavior.
- [ ] Cut a test release branch and verify the agent bumps only the patch version (e.g., `2.2.0` → `2.2.1-SNAPSHOT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GUZTBs3k2FwP4FGZMyEYB