### PR TITLE
Allow snapshot publication on PRs via publish-snapshot label

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -5,12 +5,14 @@ on:
       - main
     tags:
       - 'v*'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 jobs:
   publish:
     runs-on: macos-latest
-    if: github.repository == 'episode6/mockspresso2'
+    if: github.repository == 'episode6/mockspresso2' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'publish-snapshot'))
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 23
@@ -74,6 +76,11 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           set -e
+          # PR-triggered runs (via the publish-snapshot label) may only publish snapshots
+          if [ "${{ github.event_name }}" == "pull_request" ] && ! find bundle -type f | grep -q -- '-SNAPSHOT'; then
+            echo "Refusing to publish a non-snapshot version from a pull request"
+            exit 1
+          fi
           if find bundle -type f | grep -q -- '-SNAPSHOT'; then
             echo "Snapshot artifacts detected — uploading files individually"
             cd bundle
@@ -97,10 +104,13 @@ jobs:
           fi
 
       - name: Generate API Docs
+        if: github.event_name != 'pull_request'
         run: ./gradlew dokkaGenerateHtml
       - name: Prepare Site Docs
+        if: github.event_name != 'pull_request'
         run: ./gradlew configSite
       - name: Deploy root docs to website
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,6 +119,7 @@ jobs:
           TARGET_FOLDER: /
           CLEAN: false
       - name: Deploy dokka to website
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@132898c54c57c7cc6b80eb3a89968de8fc283505
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger (types: `opened`, `synchronize`, `reopened`, `labeled`) to `publish-artifacts.yml` so the snapshot publication flow can run on PRs.
- The `publish` job only runs for PR events when the `publish-snapshot` label is present; pushes to `main` and `v*` tags behave exactly as before.
- The docs/site deploy steps are skipped for PR events, so PR runs never touch the `site` branch.
- The Sonatype publish step refuses to publish from a PR if the bundle is not a `-SNAPSHOT` version, so labeling a release version-bump PR cannot accidentally publish a release.

## Notes
- Adding the `publish-snapshot` label to an open PR triggers a run immediately (via the `labeled` event); subsequent pushes to a labeled PR also publish.
- Workflow-only change; `verify-docs-updated.sh` classifies workflow files as non-code, so no changelog entry is required.
- Same change as episode6/redux-store-flow#110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s8pDErVG9mvJwGQJWCBDk